### PR TITLE
Made error handlers protected instead of private

### DIFF
--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -184,7 +184,7 @@ class CurlClient implements ClientInterface
      * @param $logger
      * @throws \Adyen\AdyenException
      */
-    private function handleCurlError($url, $errno, $message, $logger)
+    protected function handleCurlError($url, $errno, $message, $logger)
     {
         switch ($errno) {
             case CURLE_OK:
@@ -217,7 +217,7 @@ class CurlClient implements ClientInterface
      * @param $logger
      * @throws \Adyen\AdyenException
      */
-    private function handleResultError($result, $logger)
+    protected function handleResultError($result, $logger)
     {
         $decodeResult = json_decode($result, true);
 


### PR DESCRIPTION
I wanted to extend the CurlClient of Adyen to add some custom functionality to the HTTP client. 
I created my own CurlClient class which extends Adyens' CurlClient. I only wanted to add some small pieces of code, so I want to reuse as much as possible. Currently the methods handleCurlError and handleResultError are private. 
I want to suggest to make them protected so they can be inherited.

Issue #12 would be even better, but hasn't been resolved yet and I don't have enough time to do that.

