### PR TITLE
Also testing php 7.0 and 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
   - nightly
 before_script:


### PR DESCRIPTION
Title speaks for itself, I saw the nightly option which currently tests for PHP 7.2.0, but I think it's better to also test 7.0 and 7.1.