### PR TITLE
#40 remove recurring.contract as required field

### DIFF
--- a/src/Adyen/Service/ResourceModel/Recurring/ListRecurringDetails.php
+++ b/src/Adyen/Service/ResourceModel/Recurring/ListRecurringDetails.php
@@ -7,9 +7,7 @@ class ListRecurringDetails extends \Adyen\Service\AbstractResource
 
     protected $_requiredFields = array(
         'merchantAccount',
-        'shopperReference',
-        'recurring',
-        'recurring.contract'
+        'shopperReference'
     );
 
     public function __construct($service)


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Contract is not required anymore so you can retrieve ONECLICK and RECURRING contracts in one call.

**Tested scenarios**
<!-- Description of tested scenarios -->
Tested with all test cases

**Fixed issue**:  <!-- #-prefixed issue number -->
#40