### PR TITLE
forces code always a integer :muscle:

### DIFF
--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -22,7 +22,7 @@ class AdyenException extends Exception
     {
         $this->_status = $status;
         $this->_errorType = $errorType;
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int) $code, $previous);
     }
 
     /**


### PR DESCRIPTION
**Description**
The payment API is responding at times to a string instead of number, this is breaking the standard PHP exception.
