### PR TITLE
Add adjustAuthorisation to modification models

### DIFF
--- a/src/Adyen/Service/Modification.php
+++ b/src/Adyen/Service/Modification.php
@@ -9,7 +9,7 @@ class Modification extends \Adyen\Service
     protected $_cancelOrRefund;
     protected $_capture;
     protected $_refund;
-    protected $_adjustAthorisation;
+    protected $_adjustAuthorisation;
 
     public function __construct(\Adyen\Client $client)
     {
@@ -19,7 +19,7 @@ class Modification extends \Adyen\Service
         $this->_cancelOrRefund = new \Adyen\Service\ResourceModel\Modification\CancelOrRefund($this);
         $this->_capture = new \Adyen\Service\ResourceModel\Modification\Capture($this);
         $this->_refund = new \Adyen\Service\ResourceModel\Modification\Refund($this);
-        $this->_adjustAthorisation = new \Adyen\Service\ResourceModel\Modification\AdjustAuthorisation($this);
+        $this->_adjustAuthorisation = new \Adyen\Service\ResourceModel\Modification\AdjustAuthorisation($this);
     }
 
     public function cancel($params)
@@ -48,8 +48,7 @@ class Modification extends \Adyen\Service
 
     public function adjustAuthorisation($params)
     {
-        $result =  $this->_adjustAthorisation->request($params);
+        $result =  $this->_adjustAuthorisation->request($params);
         return $result;
     }
-
 }

--- a/src/Adyen/Service/Modification.php
+++ b/src/Adyen/Service/Modification.php
@@ -9,6 +9,7 @@ class Modification extends \Adyen\Service
     protected $_cancelOrRefund;
     protected $_capture;
     protected $_refund;
+    protected $_adjustAthorisation;
 
     public function __construct(\Adyen\Client $client)
     {
@@ -18,6 +19,7 @@ class Modification extends \Adyen\Service
         $this->_cancelOrRefund = new \Adyen\Service\ResourceModel\Modification\CancelOrRefund($this);
         $this->_capture = new \Adyen\Service\ResourceModel\Modification\Capture($this);
         $this->_refund = new \Adyen\Service\ResourceModel\Modification\Refund($this);
+        $this->_adjustAthorisation = new \Adyen\Service\ResourceModel\Modification\AdjustAuthorisation($this);
     }
 
     public function cancel($params)
@@ -41,6 +43,12 @@ class Modification extends \Adyen\Service
     public function refund($params)
     {
         $result =  $this->_refund->request($params);
+        return $result;
+    }
+
+    public function adjustAuthorisation($params)
+    {
+        $result =  $this->_adjustAthorisation->request($params);
         return $result;
     }
 

--- a/src/Adyen/Service/ResourceModel/Modification/AdjustAuthorisation.php
+++ b/src/Adyen/Service/ResourceModel/Modification/AdjustAuthorisation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Modification;
+
+class AdjustAuthorisation extends \Adyen\Service\AbstractResource
+{
+    protected $_requiredFields = array(
+        'merchantAccount',
+        'originalReference',
+        'modificationAmount.value',
+        'modificationAmount.currency',
+    );
+
+    protected $_endpoint;
+
+    public function __construct($service)
+    {
+        $this->_endpoint = $service->getClient()->getConfig()->get('endpoint').'/pal/servlet/Payment/'.$service->getClient()->getApiVersion().'/adjustAuthorisation';
+        parent::__construct($service, $this->_endpoint, $this->_requiredFields);
+    }
+
+}

--- a/tests/ModificationTest.php
+++ b/tests/ModificationTest.php
@@ -79,12 +79,12 @@ class ModificationTest extends TestCase
         // initialize service
         $service = new Service\Modification($client);
 
-        $params = [
+        $params = array(
             "merchantAccount" => $this->_merchantAccount,
-            "modificationAmount" => ['currency' => 'EUR', 'value' => '750'],
+            "modificationAmount" => array('currency' => 'EUR', 'value' => '750'),
             "reference" => $pspReference.'_adjustAuthorisation',
             "originalReference" => $pspReference
-        ];
+        );
         
         $result = $service->adjustAuthorisation($params);
 
@@ -107,12 +107,12 @@ class ModificationTest extends TestCase
         // initialize service
         $service = new Service\Modification($client);
 
-        $params = [
+        $params = array(
             "merchantAccount" => $this->_merchantAccount,
-            "modificationAmount" => ['currency' => 'EUR', 'value' => '1600'],
+            "modificationAmount" => array('currency' => 'EUR', 'value' => '1600'),
             "reference" => $pspReference.'_adjustAuthorisation',
             "originalReference" => $pspReference
-        ];
+        );
         
         $result = $service->adjustAuthorisation($params);
 

--- a/tests/ModificationTest.php
+++ b/tests/ModificationTest.php
@@ -15,7 +15,7 @@ class ModificationTest extends TestCase
     public function testCancelModification()
     {
         // create a payment
-        require_once __DIR__ . '/CreatePaymentRequestTest.php';
+        require_once __DIR__.'/CreatePaymentRequestTest.php';
         $test = new CreatePaymentRequestTest();
         $result = $test->testCreatePaymentSuccess();
 
@@ -36,7 +36,7 @@ class ModificationTest extends TestCase
     public function testRefundModification()
     {
         // create a payment
-        require_once __DIR__ . '/CreatePaymentRequestTest.php';
+        require_once __DIR__.'/CreatePaymentRequestTest.php';
         $test = new CreatePaymentRequestTest();
         $result = $test->testCreatePaymentSuccess();
 
@@ -53,13 +53,70 @@ class ModificationTest extends TestCase
         $params = array(
             "merchantAccount" => $this->_merchantAccount,
             "modificationAmount" => $modificationAmount,
-            "reference" => $pspReference . '_refund',
+            "reference" => $pspReference.'_refund',
             "originalReference" => $pspReference
         );
 
         $result = $service->refund($params);
 
         $this->assertEquals('[refund-received]', $result['response']);
+
+    }
+
+
+    public function testAdjustDecreaseModification()
+    {
+        // create a payment
+        require_once __DIR__.'/CreatePaymentRequestTest.php';
+        $test = new CreatePaymentRequestTest();
+        $result = $test->testCreatePaymentSuccess();
+
+        $pspReference = $result['pspReference'];
+
+        // create modification
+        $client = $this->createClient();
+
+        // initialize service
+        $service = new Service\Modification($client);
+
+        $params = [
+            "merchantAccount" => $this->_merchantAccount,
+            "modificationAmount" => ['currency' => 'EUR', 'value' => '750'],
+            "reference" => $pspReference.'_adjustAuthorisation',
+            "originalReference" => $pspReference
+        ];
+        
+        $result = $service->adjustAuthorisation($params);
+
+        $this->assertEquals('[adjustAuthorisation-received]', $result['response']);
+
+    }
+
+    public function testAdjustIncreaseModification()
+    {
+        // create a payment
+        require_once __DIR__.'/CreatePaymentRequestTest.php';
+        $test = new CreatePaymentRequestTest();
+        $result = $test->testCreatePaymentSuccess();
+
+        $pspReference = $result['pspReference'];
+
+        // create modification
+        $client = $this->createClient();
+
+        // initialize service
+        $service = new Service\Modification($client);
+
+        $params = [
+            "merchantAccount" => $this->_merchantAccount,
+            "modificationAmount" => ['currency' => 'EUR', 'value' => '1600'],
+            "reference" => $pspReference.'_adjustAuthorisation',
+            "originalReference" => $pspReference
+        ];
+        
+        $result = $service->adjustAuthorisation($params);
+
+        $this->assertEquals('[adjustAuthorisation-received]', $result['response']);
 
     }
 


### PR DESCRIPTION
**Description**
I wanted to use the API call for `adjustAuthorisation` in v30.
So I added the modification method in the php library. 

**Tested scenarios**
I created two tests in `ModificationTest.php` that increases and decreases the previously authorised amount.

**Fixed issue**:  <!-- #-prefixed issue number -->
