### PR TITLE
Add skipDetails.shtml endpoints to the main Client and getter and setter

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -14,6 +14,8 @@ class Client
     const ENDPOINT_LIVE                 = "https://pal-live.adyen.com";
     const ENPOINT_TEST_DIRECTORY_LOOKUP = "https://test.adyen.com/hpp/directory/v2.shtml";
     const ENPOINT_LIVE_DIRECTORY_LOOKUP = "https://live.adyen.com/hpp/directory/v2.shtml";
+    const ENPOINT_TEST_SKIP_DETAILS     = "https://test.adyen.com/hpp/skipDetails.shtml";
+    const ENPOINT_LIVE_SKIP_DETAILS     = "https://live.adyen.com/hpp/skipDetails.shtml";
     const API_VERSION                   = "v30";
     const API_RECURRING_VERSION         = "v25";
 
@@ -83,10 +85,12 @@ class Client
             $this->_config->set('environment', \Adyen\Environment::TEST);
             $this->_config->set('endpoint', self::ENDPOINT_TEST);
             $this->_config->set('endpointDirectorylookup', self::ENPOINT_TEST_DIRECTORY_LOOKUP);
+            $this->_config->set('endpointSkipDetails', self::ENPOINT_TEST_SKIP_DETAILS);
         } elseif($environment == \Adyen\Environment::LIVE) {
             $this->_config->set('environment', \Adyen\Environment::LIVE);
             $this->_config->set('endpoint', self::ENDPOINT_LIVE);
             $this->_config->set('endpointDirectorylookup', self::ENPOINT_LIVE_DIRECTORY_LOOKUP);
+            $this->_config->set('endpointSkipDetails', self::ENPOINT_LIVE_SKIP_DETAILS);
         } else {
             // environment does not exists
             $msg = "This environment does not exists use " . \Adyen\Environment::TEST . ' or ' . \Adyen\Environment::LIVE;
@@ -112,6 +116,26 @@ class Client
     public function setDirectoryLookupUrl($url)
     {
         $this->_config->set('endpointDirectorylookup', $url);
+    }
+
+    /**
+     * Set SkipDetails URL
+     *
+     * @param $url
+     */
+    public function setSkipDetailsUrl($url)
+    {
+        $this->_config->set('endpointSkipDetails', $url);
+    }
+
+    /**
+     * Get SkipDetails URL
+     *
+     * @return  $url
+     */
+    public function getSkipDetailsUrl()
+    {
+        return $this->_config->get('endpointSkipDetails');
     }
 
     public function setMerchantAccount($merchantAccount)

--- a/tests/SkipDetailsTest.php
+++ b/tests/SkipDetailsTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rikt
+ * Date: 11/6/15
+ * Time: 2:53 PM
+ */
+
+namespace Adyen;
+
+
+use Adyen\Util\Util;
+
+class SkipDetailsTest extends TestCase
+{
+    public function testGetSandboxSkipDetailsUrl()
+    {
+        $client = $this->createClient();
+        $this->assertEquals( "https://test.adyen.com/hpp/skipDetails.shtml", $client->getSkipDetailsUrl());
+    }
+
+    public function testGetLiveSkipDetailsUrl()
+    {
+        $client = $this->createClient();
+        $client->setEnvironment(\Adyen\Environment::LIVE);
+        $this->assertEquals( "https://live.adyen.com/hpp/skipDetails.shtml", $client->getSkipDetailsUrl());
+    }
+}


### PR DESCRIPTION
**Description**
I wanted to use the Adyen Client to get the endpoint for the skipDetails functionality, so have added the test/live endpoints to the Client and added a getter and setter

**Tested scenarios**
Added a basic test for both Test and Live, to getSkipDetailsUrl() to check that we get the relevant skipDetails.shtml endpoint for each.

**Fixed issue**:  
