### PR TITLE
PW-645 use dynamic identifier for live endpoint

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -12,16 +12,18 @@ class Client
     const USER_AGENT_SUFFIX = "adyen-php-api-library/";
     const ENDPOINT_TEST = "https://pal-test.adyen.com";
     const ENDPOINT_LIVE = "https://pal-live.adyen.com";
+    const ENDPOINT_LIVE_SUFFIX = "-pal-live.adyenpayments.com";
     const ENDPOINT_TEST_DIRECTORY_LOOKUP = "https://test.adyen.com/hpp/directory/v2.shtml";
     const ENDPOINT_LIVE_DIRECTORY_LOOKUP = "https://live.adyen.com/hpp/directory/v2.shtml";
     const API_VERSION = "v30";
     const API_RECURRING_VERSION = "v25";
     const API_CHECKOUT_VERSION = "v32";
     const API_CHECKOUT_UTILITY_VERSION = "v1";
-    const TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
-    const TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
-    const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com";
-    const ENDPOINT_CHECKOUT_LIVE = "https://checkout-live.adyen.com";
+    const ENDPOINT_TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
+    const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
+    const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com/checkout";
+    const ENDPOINT_CHECKOUT_LIVE_SUFFIX = "-checkout-live.adyenpayments.com/checkout";
+    const ENDPOINT_PROTOCOL = "https://";
 
     /**
      * @var Adyen_Config $config
@@ -89,24 +91,32 @@ class Client
 
     /**
      * Set environment to connect to test or live platform of Adyen
+     * For live please specify the unique identifier.
      *
      * @param $environment
+     * @param null $liveEndpointUrlPrefix
      * @throws AdyenException
      */
-    public function setEnvironment($environment)
+    public function setEnvironment($environment, $liveEndpointUrlPrefix = null)
     {
         if ($environment == \Adyen\Environment::TEST) {
             $this->_config->set('environment', \Adyen\Environment::TEST);
             $this->_config->set('endpoint', self::ENDPOINT_TEST);
             $this->_config->set('endpointDirectorylookup', self::ENDPOINT_TEST_DIRECTORY_LOOKUP);
-            $this->_config->set('endpointTerminalCloud', self::TERMINAL_CLOUD_TEST);
+            $this->_config->set('endpointTerminalCloud', self::ENDPOINT_TERMINAL_CLOUD_TEST);
             $this->_config->set('endpointCheckout', self::ENDPOINT_CHECKOUT_TEST);
         } elseif ($environment == \Adyen\Environment::LIVE) {
             $this->_config->set('environment', \Adyen\Environment::LIVE);
-            $this->_config->set('endpoint', self::ENDPOINT_LIVE);
             $this->_config->set('endpointDirectorylookup', self::ENDPOINT_LIVE_DIRECTORY_LOOKUP);
-            $this->_config->set('endpointTerminalCloud', self::TERMINAL_CLOUD_LIVE);
-            $this->_config->set('endpointCheckout', self::ENDPOINT_CHECKOUT_LIVE);
+            $this->_config->set('endpointTerminalCloud', self::ENDPOINT_TERMINAL_CLOUD_LIVE);
+
+            if ($liveEndpointUrlPrefix) {
+                $this->_config->set('endpoint', self::ENDPOINT_PROTOCOL . $liveEndpointUrlPrefix . self::ENDPOINT_LIVE_SUFFIX);
+                $this->_config->set('endpointCheckout', self::ENDPOINT_PROTOCOL . $liveEndpointUrlPrefix . self::ENDPOINT_CHECKOUT_LIVE_SUFFIX);
+            } else {
+                $this->_config->set('endpoint', self::ENDPOINT_LIVE);
+                $this->_config->set('endpointCheckout', null); // not supported please specify unique identifier
+            }
         } else {
             // environment does not exist
             $msg = "This environment does not exist, use " . \Adyen\Environment::TEST . ' or ' . \Adyen\Environment::LIVE;

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -93,8 +93,8 @@ class Client
      * Set environment to connect to test or live platform of Adyen
      * For live please specify the unique identifier.
      *
-     * @param $environment
-     * @param null $liveEndpointUrlPrefix
+     * @param $environment test
+     * @param null $liveEndpointUrlPrefix Provide the unique live url prefix from the "API URLs and Response" menu in the Adyen Customer Area
      * @throws AdyenException
      */
     public function setEnvironment($environment, $liveEndpointUrlPrefix = null)

--- a/src/Adyen/Service/AbstractCheckoutResource.php
+++ b/src/Adyen/Service/AbstractCheckoutResource.php
@@ -17,7 +17,7 @@ class AbstractCheckoutResource extends AbstractResource
         // check if endpoint is set
         if ($service->getClient()->getConfig()->get('endpointCheckout') == null) {
             $logger = $service->getClient()->getLogger();
-            $msg = "You forgot to specify a unique identifier when setting the environment";
+            $msg =  "Please provide your unique live url prefix on the setEnvironment() call on the Client or provide endpointCheckout in your config object.";
             $logger->error($msg);
             throw new \Adyen\AdyenException($msg);
         }

--- a/src/Adyen/Service/AbstractCheckoutResource.php
+++ b/src/Adyen/Service/AbstractCheckoutResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Adyen\Service;
+
+class AbstractCheckoutResource extends AbstractResource
+{
+
+    /**
+     * Return Checkout endpoint
+     *
+     * @param $service
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function getCheckoutEndpoint($service)
+    {
+        // check if endpoint is set
+        if ($service->getClient()->getConfig()->get('endpointCheckout') == null) {
+            $logger = $service->getClient()->getLogger();
+            $msg = "You forgot to specify a unique identifier when setting the environment";
+            $logger->error($msg);
+            throw new \Adyen\AdyenException($msg);
+        }
+
+        return $service->getClient()->getConfig()->get('endpointCheckout');
+    }
+}

--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -19,21 +19,11 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function __construct(\Adyen\Client $client)
     {
         parent::__construct($client);
-
-        // check if endpoint is set
-        if ($client->getConfig()->get('endpointCheckout') == null) {
-            $logger = $client->getLogger();
-            $msg = "You forgot to specify a unique identifier when setting the environment";
-            $logger->error($msg);
-            throw new \Adyen\AdyenException($msg);
-        }
-
         $this->_paymentSession = new \Adyen\Service\ResourceModel\Checkout\PaymentSession($this);
         $this->_paymentsResult = new \Adyen\Service\ResourceModel\Checkout\PaymentsResult($this);
         $this->_paymentMethods = new \Adyen\Service\ResourceModel\Checkout\PaymentMethods($this);
         $this->_payments = new \Adyen\Service\ResourceModel\Checkout\Payments($this);
         $this->_paymentsDetails = new \Adyen\Service\ResourceModel\Checkout\PaymentsDetails($this);
-
     }
 
     public function paymentSession($params)

--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -11,9 +11,22 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $_payments;
     protected $_paymentsDetails;
 
+    /**
+     * Checkout constructor.
+     * @param \Adyen\Client $client
+     * @throws \Adyen\AdyenException
+     */
     public function __construct(\Adyen\Client $client)
     {
         parent::__construct($client);
+
+        // check if endpoint is set
+        if ($client->getConfig()->get('endpointCheckout') == null) {
+            $logger = $client->getLogger();
+            $msg = "You forgot to specify a unique identifier when setting the environment";
+            $logger->error($msg);
+            throw new \Adyen\AdyenException($msg);
+        }
 
         $this->_paymentSession = new \Adyen\Service\ResourceModel\Checkout\PaymentSession($this);
         $this->_paymentsResult = new \Adyen\Service\ResourceModel\Checkout\PaymentsResult($this);

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentMethods.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentMethods.php
@@ -2,13 +2,13 @@
 
 namespace Adyen\Service\ResourceModel\Checkout;
 
-class PaymentMethods extends \Adyen\Service\AbstractResource
+class PaymentMethods extends \Adyen\Service\AbstractCheckoutResource
 {
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutVersion() . '/paymentMethods';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutVersion() . '/paymentMethods';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentSession.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentSession.php
@@ -2,13 +2,13 @@
 
 namespace Adyen\Service\ResourceModel\Checkout;
 
-class PaymentSession extends \Adyen\Service\AbstractResource
+class PaymentSession extends \Adyen\Service\AbstractCheckoutResource
 {
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutVersion() . '/paymentSession';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutVersion() . '/paymentSession';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/src/Adyen/Service/ResourceModel/Checkout/Payments.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Payments.php
@@ -2,14 +2,14 @@
 
 namespace Adyen\Service\ResourceModel\Checkout;
 
-class Payments extends \Adyen\Service\AbstractResource
+class Payments extends \Adyen\Service\AbstractCheckoutResource
 {
 
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentsDetails.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentsDetails.php
@@ -2,13 +2,13 @@
 
 namespace Adyen\Service\ResourceModel\Checkout;
 
-class PaymentsDetails extends \Adyen\Service\AbstractResource
+class PaymentsDetails extends \Adyen\Service\AbstractCheckoutResource
 {
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments/details';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments/details';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentsResult.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentsResult.php
@@ -2,13 +2,13 @@
 
 namespace Adyen\Service\ResourceModel\Checkout;
 
-class PaymentsResult extends \Adyen\Service\AbstractResource
+class PaymentsResult extends \Adyen\Service\AbstractCheckoutResource
 {
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments/result';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutVersion() . '/payments/result';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/src/Adyen/Service/ResourceModel/CheckoutUtility/OriginKeys.php
+++ b/src/Adyen/Service/ResourceModel/CheckoutUtility/OriginKeys.php
@@ -2,13 +2,13 @@
 
 namespace Adyen\Service\ResourceModel\CheckoutUtility;
 
-class OriginKeys extends \Adyen\Service\AbstractResource
+class OriginKeys extends \Adyen\Service\AbstractCheckoutResource
 {
     protected $_endpoint;
 
     public function __construct($service)
     {
-        $this->_endpoint = $service->getClient()->getConfig()->get('endpointCheckout') .'/'. $service->getClient()->getApiCheckoutUtilityVersion() . '/originKeys';
+        $this->_endpoint = $this->getCheckoutEndpoint($service) .'/'. $service->getClient()->getApiCheckoutUtilityVersion() . '/originKeys';
         parent::__construct($service, $this->_endpoint);
     }
 

--- a/tests/MockTest/CheckoutTest.php
+++ b/tests/MockTest/CheckoutTest.php
@@ -60,7 +60,7 @@ class CheckoutTest extends TestCaseMock
     public static function failurePaymentMethodsMissingIdentifierOnLiveProvider()
     {
         return array(
-            array('tests/Resources/Checkout/payment-methods-success.json', null, 'You forgot to specify a unique identifier when setting the environment')
+            array('tests/Resources/Checkout/payment-methods-success.json', null, 'Please provide your unique live url prefix on the setEnvironment() call on the Client or provide endpointCheckout in your config object.')
         );
     }
 

--- a/tests/MockTest/CheckoutTest.php
+++ b/tests/MockTest/CheckoutTest.php
@@ -30,7 +30,37 @@ class CheckoutTest extends TestCaseMock
     public static function successPaymentMethodsProvider()
     {
         return array(
-            array('tests/Resources/Checkout/payment-methods-success.json', 200),
+            array('tests/Resources/Checkout/payment-methods-success.json', 200)
+        );
+    }
+
+    /**
+     * @param $jsonFile
+     * @param $httpStatus
+     * @param $expectedExceptionMessage
+     * @throws \Adyen\AdyenException
+     * @dataProvider failurePaymentMethodsMissingIdentifierOnLiveProvider
+     */
+    public function testPaymentMethodsFailureMissingIdentifierOnLive($jsonFile, $httpStatus, $expectedExceptionMessage)
+    {
+        // create Checkout client
+        $client = $this->createMockClient($jsonFile, $httpStatus);
+        $client->setEnvironment(\Adyen\Environment::LIVE);
+
+        try {
+            $service = new \Adyen\Service\Checkout($client);
+            $params = array('merchantAccount' => "YourMerchantAccount");
+            $service->paymentMethods($params);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Adyen\AdyenException', $e);
+            $this->assertContains($expectedExceptionMessage, $e->getMessage());
+        }
+    }
+
+    public static function failurePaymentMethodsMissingIdentifierOnLiveProvider()
+    {
+        return array(
+            array('tests/Resources/Checkout/payment-methods-success.json', null, 'You forgot to specify a unique identifier when setting the environment')
         );
     }
 
@@ -39,7 +69,6 @@ class CheckoutTest extends TestCaseMock
      * @param $httpStatus
      * @param $expectedExceptionMessage
      * @dataProvider failurePaymentMethodsProvider
-     *
      */
     public function testPaymentMethodsFailure($jsonFile, $httpStatus, $expectedExceptionMessage)
     {


### PR DESCRIPTION
PW-645 use dynamic identifier for live if provided, not provided throw error for checkout service as this is mandatory

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
Added checkout live test for this.

**Fixed issue**:  <!-- #-prefixed issue number -->
