### PR TITLE
fix local unit test running caused by the missing date_default_timezone_set

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -93,7 +93,7 @@ class Client
      * Set environment to connect to test or live platform of Adyen
      * For live please specify the unique identifier.
      *
-     * @param $environment test
+     * @param $environment
      * @param null $liveEndpointUrlPrefix Provide the unique live url prefix from the "API URLs and Response" menu in the Adyen Customer Area
      * @throws AdyenException
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,15 +9,33 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected $_skinCode;
     protected $_hmacSignature;
 
+	/**
+	 * Settings parsed from the config/tests.ini file
+	 *
+	 * @var array
+	 */
+    protected $settings;
+
     public function __construct()
     {
-
         $this->_merchantAccount = $this->getMerchantAccount();
         $this->_skinCode = $this->getSkinCode();
         $this->_hmacSignature = $this->getHmacSignature();
+		$this->settings = $this->_loadConfigIni();
 
+		$this->setDefaultsDuringDevelopment();
     }
 
+	/**
+	 * During development of the standalone php api library this function sets the necessary defaults which would
+	 * otherwise set by the merchant
+	 */
+    private function setDefaultsDuringDevelopment()
+	{
+		if ($this->isStandaloneLibraryDevelopmentInProgress()) {
+			date_default_timezone_set('Europe/Amsterdam');
+		}
+	}
 
 	/**
 	 * Mock client
@@ -27,7 +45,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	protected function createClient()
 	{
 		// load settings from .ini file
-		$settings = $this->_loadConfigIni();
+		$settings = $this->settings;
 
 		// validate username, password and MERCHANTAccount
 
@@ -64,7 +82,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	protected function createPayoutClient()
 	{
 		// load settings from .ini file
-		$settings = $this->_loadConfigIni();
+		$settings = $this->settings;
 
 		// validate username, password and MERCHANTAccount
 
@@ -101,7 +119,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	protected function createReviewPayoutClient()
 	{
 		// load settings from .ini file
-		$settings = $this->_loadConfigIni();
+		$settings = $this->settings;
 
 		// validate username, password and MERCHANTAccount
 
@@ -133,7 +151,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	protected function createTerminalCloudAPIClient()
     {
         // load settings from .ini file
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['x-api-key']) || !isset($settings['POIID']) || $settings['x-api-key'] == 'YOUR X-API KEY' || $settings['POIID'] == 'UNIQUETERMINALID'){
             $this->_skipTest("Skipped the test. Configure your x-api-key and POIID in the config");
@@ -153,7 +171,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $client = $this->createClient();
 
         // load settings from .ini file
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['merchantAccount']) || $settings['merchantAccount'] == 'YOUR MERCHANTACCOUNT') {
             $this->_skipTest("Skipped the test. Configure your MerchantAccount in the config");
@@ -166,7 +184,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getMerchantAccount()
     {
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['merchantAccount']) || $settings['merchantAccount'] == 'YOUR MERCHANTACCOUNT') {
             return null;
@@ -177,7 +195,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getSkinCode()
     {
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['skinCode']) || $settings['skinCode'] == 'YOUR SKIN CODE') {
             return null;
@@ -188,7 +206,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getHmacSignature()
     {
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['hmacSignature'])|| $settings['hmacSignature'] == 'YOUR HMAC SIGNATURE') {
             return null;
@@ -199,7 +217,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getPOIID()
     {
-        $settings = $this->_loadConfigIni();
+        $settings = $this->settings;
 
         if(!isset($settings['POIID']) || $settings['POIID'] == 'MODEL-SERIALNUMBER') {
             return null;
@@ -225,6 +243,23 @@ class TestCase extends \PHPUnit_Framework_TestCase
 		}
 	}
 
+	/**
+	 * In case of developing the api library alone zou can set the standalone_library_development_in_progress property
+	 * true to set up the default missing values for local development which otherwise would set by the merchant
+	 *
+	 * @return bool
+	 */
+	protected function isStandaloneLibraryDevelopmentInProgress()
+	{
+		$settings = $this->settings;
+
+		if(!isset($settings['standalone_library_development_in_progress'])) {
+			return false;
+		}
+
+		return $settings['standalone_library_development_in_progress'];
+	}
+	
     public function validateApiPermission($e)
     {
         // it is possible you do not have permission to use full API then switch over to CSE
@@ -240,5 +275,4 @@ class TestCase extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped("Skipped the test. You do not have the permission to do a recurring transaction.");
         }
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,8 +32,11 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	 */
     private function setDefaultsDuringDevelopment()
 	{
-		if ($this->isStandaloneLibraryDevelopmentInProgress()) {
-			date_default_timezone_set('Europe/Amsterdam');
+		if ($this->isDev()) {
+			// Check default timezone if not set use a default value for that
+			if (!ini_get('date.timezone')) {
+				ini_set('date.timezone', 'Europe/Amsterdam');
+			}
 		}
 	}
 
@@ -249,20 +252,20 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * In case of developing the api library alone you can set the standalone_library_development_in_progress property
+	 * In case of developing the api library alone you can set the dev property
 	 * true to set up the default missing values for local development which otherwise would set by the merchant
 	 *
 	 * @return bool
 	 */
-	protected function isStandaloneLibraryDevelopmentInProgress()
+	protected function isDev()
 	{
 		$settings = $this->settings;
 
-		if(!isset($settings['standalone_library_development_in_progress'])) {
+		if(!isset($settings['dev'])) {
 			return false;
 		}
 
-		return $settings['standalone_library_development_in_progress'];
+		return $settings['dev'];
 	}
 	
     public function validateApiPermission($e)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,11 +32,9 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	 */
     private function setDefaultsDuringDevelopment()
 	{
-		if ($this->isDev()) {
-			// Check default timezone if not set use a default value for that
-			if (!ini_get('date.timezone')) {
-				ini_set('date.timezone', 'Europe/Amsterdam');
-			}
+		// Check default timezone if not set use a default value for that
+		if (!ini_get('date.timezone')) {
+			ini_set('date.timezone', 'Europe/Amsterdam');
 		}
 	}
 
@@ -249,23 +247,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
 		if (!$this->_skinCode) {
 			$this->_skipTest("Skipped the test. Configure your SkinCode in the config");
 		}
-	}
-
-	/**
-	 * In case of developing the api library alone you can set the dev property
-	 * true to set up the default missing values for local development which otherwise would set by the merchant
-	 *
-	 * @return bool
-	 */
-	protected function isDev()
-	{
-		$settings = $this->settings;
-
-		if(!isset($settings['dev'])) {
-			return false;
-		}
-
-		return $settings['dev'];
 	}
 	
     public function validateApiPermission($e)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected $_hmacSignature;
 
 	/**
-	 * Settings parsed from the config/tests.ini file
+	 * Settings parsed from the config/test.ini file
 	 *
 	 * @var array
 	 */
@@ -226,6 +226,11 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $settings['POIID'];
     }
 
+	/**
+	 * Loads the settings into and array from the config/test.ini file
+	 *
+	 * @return array|bool
+	 */
     protected function _loadConfigIni()
     {
         return parse_ini_file(__DIR__ . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'test.ini', true);
@@ -244,7 +249,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * In case of developing the api library alone zou can set the standalone_library_development_in_progress property
+	 * In case of developing the api library alone you can set the standalone_library_development_in_progress property
 	 * true to set up the default missing values for local development which otherwise would set by the merchant
 	 *
 	 * @return bool

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -11,5 +11,3 @@ storePayoutUsername = YOUR STORE PAYOUT USERNAME
 storePayoutPassword = "YOUR STORE PAYOUT PASSWORD"
 reviewPayoutUsername = YOUR REVIEW PAYOUT USERNAME
 reviewPayoutPassword = "YOUR REVIEW PAYOUT PASSWORD"
-
-dev = false

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -12,4 +12,4 @@ storePayoutPassword = "YOUR STORE PAYOUT PASSWORD"
 reviewPayoutUsername = YOUR REVIEW PAYOUT USERNAME
 reviewPayoutPassword = "YOUR REVIEW PAYOUT PASSWORD"
 
-standalone_library_development_in_progress = false
+dev = false

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -11,3 +11,5 @@ storePayoutUsername = YOUR STORE PAYOUT USERNAME
 storePayoutPassword = "YOUR STORE PAYOUT PASSWORD"
 reviewPayoutUsername = YOUR REVIEW PAYOUT USERNAME
 reviewPayoutPassword = "YOUR REVIEW PAYOUT PASSWORD"
+
+standalone_library_development_in_progress = false


### PR DESCRIPTION
**Description**
Add new setting to the config/tests.ini where it can be set if you are
working on the api library standalone on local
When this setting is set true then the missing defaults that can cause
issues are being set
