### PR TITLE
Update checkout API version to v40

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -18,7 +18,7 @@ class Client
     const ENDPOINT_LIVE_DIRECTORY_LOOKUP = "https://live.adyen.com/hpp/directory/v2.shtml";
     const API_VERSION = "v30";
     const API_RECURRING_VERSION = "v25";
-    const API_CHECKOUT_VERSION = "v32";
+    const API_CHECKOUT_VERSION = "v40";
     const API_CHECKOUT_UTILITY_VERSION = "v1";
     const ENDPOINT_TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";

--- a/tests/CheckoutTest.php
+++ b/tests/CheckoutTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Adyen;
+
+use Adyen\Util\Util;
+
+class CheckoutTest extends TestCase
+{
+    public function testPaymentMethods()
+    {
+        $client = $this->createCheckoutAPIClient();
+
+        $service = new Service\Checkout($client);
+
+        $params = array(
+            'amount' => 1000,
+            'countryCode' => 'NL',
+            'shopperLocale' => 'nl_NL',
+            'merchantAccount' => $this->_merchantAccount,
+        );
+
+        $result = $service->paymentMethods($params);
+
+        $this->assertInternalType('array',$result);
+
+        // needs to have Ideal in result because country is netherlands
+        $hasIdeal = false;
+        foreach($result['paymentMethods'] as $paymentMethod) {
+            if($paymentMethod['type'] == 'ideal') {
+                $hasIdeal = true;
+            }
+        }
+
+        $this->assertEquals(true, $hasIdeal);
+    }
+
+    public function testBlockedPaymentMethods()
+    {
+        $client = $this->createCheckoutAPIClient();
+
+        $service = new Service\Checkout($client);
+
+        $params = array(
+            'amount' => 1000,
+            'countryCode' => 'NL',
+            'shopperLocale' => 'nl_NL',
+            'merchantAccount' => $this->_merchantAccount,
+            'blockedPaymentMethods' => array('ideal'),
+        );
+
+        $result = $service->paymentMethods($params);
+
+        $this->assertInternalType('array',$result);
+
+        $hasIdeal = false;
+        foreach($result['paymentMethods'] as $paymentMethod) {
+            if($paymentMethod['type'] == 'ideal') {
+                $hasIdeal = true;
+            }
+        }
+
+        $this->assertFalse($hasIdeal);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,10 +18,10 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     public function __construct()
     {
+        $this->settings = $this->_loadConfigIni();
         $this->_merchantAccount = $this->getMerchantAccount();
         $this->_skinCode = $this->getSkinCode();
         $this->_hmacSignature = $this->getHmacSignature();
-		$this->settings = $this->_loadConfigIni();
 
 		$this->setDefaultsDuringDevelopment();
     }
@@ -199,6 +199,21 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
         $client->setMerchantAccount($settings['merchantAccount']);
         return $client;
+    }
+
+    protected function createCheckoutAPIClient()
+    {
+        $client = $this->createClientWithMerchantAccount();
+
+        // load settings from .ini file
+        $settings = $this->settings;
+
+        if(!isset($settings['x-api-key']) || $settings['x-api-key'] == 'YOUR X-API KEY'){
+            $this->_skipTest("Skipped the test. Configure your x-api-key");
+        }else{
+            $client->setXApiKey($settings['x-api-key']);
+            return $client;
+        }
     }
 
     protected function getMerchantAccount()


### PR DESCRIPTION
**Description**
v40 has some useful features that we need. A separate test case was added to verify the behaviour.

**Tested scenarios**
Tested the behavior with and without `blockedPaymentMethods` to verify that v40 is used.