### PR TITLE
Allow the library to be used with Monolog 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.3",
-    "monolog/monolog": "~1.16"
+    "monolog/monolog": ">=1.16"
   },
   "require-dev": {
     "phpunit/phpunit": "~4",

--- a/tests/MockTest/PaymentTest.php
+++ b/tests/MockTest/PaymentTest.php
@@ -2,8 +2,6 @@
 
 namespace Adyen\MockTest;
 
-use Monolog\Handler\StreamHandler;
-
 class PaymentTest extends TestCaseMock
 {
     /**

--- a/tests/MockTest/PaymentTest.php
+++ b/tests/MockTest/PaymentTest.php
@@ -2,6 +2,9 @@
 
 namespace Adyen\MockTest;
 
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+
 class PaymentTest extends TestCaseMock
 {
     /**
@@ -15,18 +18,12 @@ class PaymentTest extends TestCaseMock
         // create client
         $client = $this->createMockClient($jsonFile, $httpStatus);
 
+        $handler = new TestHandler();
+
+        $logger = new Logger('test', array($handler));
+
         // Stub Logger to prevent full card data being logged
-        $loggerMock = $this->getMockBuilder('\Monolog\Logger')->setMethods(array('info'))->disableOriginalConstructor()->getMock();
-        $client->setLogger($loggerMock);
-        $loggerMock->expects($this->any())
-            ->method('info')
-            ->with(
-                $this->logicalAnd(
-                    $this->logicalNot($this->stringContains('4111')),
-                    $this->logicalNot($this->stringContains('737')),
-                    $this->logicalNot($this->stringContains('adyenjs....'))
-                )
-            );
+        $client->setLogger($logger);
 
         // initialize service
         $service = new \Adyen\Service\Payment($client);
@@ -56,6 +53,10 @@ class PaymentTest extends TestCaseMock
 
         $this->assertArrayHasKey('resultCode', $result);
         $this->assertEquals('Authorised', $result['resultCode']);
+
+        $this->assertFalse($handler->hasInfoThatContains('4111'));
+        $this->assertFalse($handler->hasInfoThatContains('737'));
+        $this->assertFalse($handler->hasInfoThatContains('adyenjs....'));
     }
 
     public static function successAuthoriseProvider()

--- a/tests/MockTest/PosPaymentTest.php
+++ b/tests/MockTest/PosPaymentTest.php
@@ -2,8 +2,6 @@
 
 namespace Adyen\MockTest;
 
-use Monolog\Handler\StreamHandler;
-
 class PosPaymentTest extends TestCaseMock
 {
     /**


### PR DESCRIPTION
**Description**
Monolog has [released v2.0.0](https://github.com/Seldaek/monolog/releases/tag/2.0.0), but the Adyen PHP library blocks upgrading to this version.

Because Monolog 2.0.0 requires at least PHP 7.2, the version constraint for this library can't just be upped to v2, because that would drop support for PHP5.3

With the `>=1.16` users have the possibility of choosing the version of Monolog which suits them