### PR TITLE
Update API_FUND_VERSION from v3 to v5

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -24,7 +24,7 @@ class Client
     const API_CHECKOUT_UTILITY_VERSION = "v1";
     const API_NOTIFICATION_VERSION = "v1";
     const API_ACCOUNT_VERSION = "v5";
-    const API_FUND_VERSION = "v3";
+    const API_FUND_VERSION = "v5";
     const ENDPOINT_TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
     const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com/checkout";


### PR DESCRIPTION
**Description**
The Fund API version is still set to use the v3 version, so I update this constant to be able to use the v5 fund API

**Tested scenarios**

**Fixed issue**:

