### PR TITLE
Fixed PHPDoc for AdyenException

### DIFF
--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -27,9 +27,9 @@ class AdyenException extends Exception
      * @param string $message
      * @param int $code
      * @param Exception|null $previous
-     * @param ?string $status
-     * @param ?string $errorType
-     * @param ?string $pspReference
+     * @param string|null $status
+     * @param string|null $errorType
+     * @param string|null $pspReference
      */
 	public function __construct(
 	    $message = "",
@@ -48,7 +48,7 @@ class AdyenException extends Exception
 	/**
 	 * Get status
 	 *
-	 * @return ?string
+	 * @return string|null
 	 */
 	public function getStatus()
 	{
@@ -58,7 +58,7 @@ class AdyenException extends Exception
 	/**
 	 * Get Adyen Error type
 	 * 
-	 * @return ?string
+	 * @return string|null
 	 */
 	public function getErrorType()
 	{
@@ -66,7 +66,7 @@ class AdyenException extends Exception
 	}
 
     /**
-     * @return ?string
+     * @return string|null
      */
     public function getPspReference()
     {

--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -27,9 +27,9 @@ class AdyenException extends Exception
      * @param string $message
      * @param int $code
      * @param Exception|null $previous
-     * @param null $status
-     * @param null $errorType
-     * @param null $pspReference
+     * @param ?string $status
+     * @param ?string $errorType
+     * @param ?string $pspReference
      */
 	public function __construct(
 	    $message = "",
@@ -48,7 +48,7 @@ class AdyenException extends Exception
 	/**
 	 * Get status
 	 *
-	 * @return null
+	 * @return ?string
 	 */
 	public function getStatus()
 	{
@@ -57,6 +57,8 @@ class AdyenException extends Exception
 
 	/**
 	 * Get Adyen Error type
+	 * 
+	 * @return ?string
 	 */
 	public function getErrorType()
 	{
@@ -64,7 +66,7 @@ class AdyenException extends Exception
 	}
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getPspReference()
     {


### PR DESCRIPTION
Description
So that Static Analysis tools like PHPStan/Psalm work properly with files that make use of this class.

Tested scenarios
Although I couldn't find any uses of the additional constructor arguments, the only changes in this PR are PHPDocs used by tools mentioned above

Fixed issue:

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
