### PR TITLE
PW-1904 Upgrade checkout API endpoint from v49 to v51

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -20,7 +20,7 @@ class Client
     const API_BIN_LOOKUP_VERSION = "v40";
     const API_PAYOUT_VERSION = "v30";
     const API_RECURRING_VERSION = "v25";
-    const API_CHECKOUT_VERSION = "v49";
+    const API_CHECKOUT_VERSION = "v51";
     const API_CHECKOUT_UTILITY_VERSION = "v1";
     const API_NOTIFICATION_VERSION = "v1";
     const API_ACCOUNT_VERSION = "v5";


### PR DESCRIPTION
**Description**
Bump API_CHECKOUT_VERSION from v49 to v51

Important note:
Multibanco response changes from Received to PrestnToShopper

Example response from v49
```
{
    "additionalData": {
        "comprafacil.deadline": "1",
        "comprafacil.reference": "111 111 1111",
        "paymentMethod": "multibanco",
        "refusalReasonRaw": "Setup performed successfully",
        "comprafacil.entity": "11111",
        "merchantReference": "0001",
        "comprafacil.amount": "10.00",
        "acquirerCode": "***",
        "acquirerReference": "111 111 111"
    },
    "pspReference": "***",
    "resultCode": "Received",
    "merchantReference": "0001"
}
```

Example response from v51:
```
{
    "resultCode": "PresentToShopper",
    "action": {
        "expiresAt": "2019-12-12T12:55:25",
        "initialAmount": {
            "currency": "EUR",
            "value": 1000
        },
        "merchantName": "****",
        "merchantReference": "0001",
        "paymentMethodType": "multibanco",
        "reference": "111 111 111",
        "totalAmount": {
            "currency": "EUR",
            "value": 1000
        },
        "type": "voucher"
    }
}
```