### PR TITLE
PW-1188: Add applicationInfo into terminal API requests

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -223,6 +223,17 @@ class Client
     }
 
     /**
+     * Set merchant application name and version
+     *
+     * @param string $name
+     * @param string $version
+     */
+    public function setMerchantApplication($name, $version)
+    {
+        $this->config->set('merchantApplication', array('name' => $name, 'version' => $version));
+    }
+
+    /**
      * Type can be json or array
      *
      * @param $value

--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -151,7 +151,7 @@ class Config implements ConfigInterface
 	}
 
     /**
-     * @return mixed|null
+     * @return array|null an array with 'name' and 'version'
      */
     public function getMerchantApplication()
     {

--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -150,6 +150,14 @@ class Config implements ConfigInterface
 		return isset($this->data['adyenPaymentSource']) ? $this->data['adyenPaymentSource'] : null;
 	}
 
+    /**
+     * @return mixed|null
+     */
+    public function getMerchantApplication()
+    {
+        return isset($this->data['merchantApplication']) ? $this->data['merchantApplication'] : null;
+    }
+
 	/**
 	 * @return mixed|null
 	 */

--- a/src/Adyen/ConfigInterface.php
+++ b/src/Adyen/ConfigInterface.php
@@ -2,6 +2,11 @@
 
 namespace Adyen;
 
+/**
+ * Interface ConfigInterface
+ * @deprecated Please do not use your own interface as we will deprecate this in the future for improvements on the library
+ * @package Adyen
+ */
 Interface ConfigInterface
 {
 

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -72,6 +72,11 @@ abstract class AbstractResource
             $params = $this->handleApplicationInfoInRequest($params);
         } elseif ($this->allowApplicationInfoPOS) {
             $params = $this->handleApplicationInfoInRequestPOS($params);
+        } else {
+            // remove if exists
+            if (isset($params['applicationInfo'])) {
+                unset($params['applicationInfo']);
+            }
         }
 
 		$curlClient = $this->service->getClient()->getHttpClient();
@@ -121,37 +126,29 @@ abstract class AbstractResource
 	 */
 	private function handleApplicationInfoInRequest($params)
 	{
-		// Only add if allowed
-		if ($this->allowApplicationInfo || $this->allowApplicationInfoPOS) {
-			// add/overwrite applicationInfo adyenLibrary even if it's already set
-			$params['applicationInfo']['adyenLibrary']['name'] = $this->service->getClient()->getLibraryName();
-			$params['applicationInfo']['adyenLibrary']['version'] = $this->service->getClient()->getLibraryVersion();
+        // add/overwrite applicationInfo adyenLibrary even if it's already set
+        $params['applicationInfo']['adyenLibrary']['name'] = $this->service->getClient()->getLibraryName();
+        $params['applicationInfo']['adyenLibrary']['version'] = $this->service->getClient()->getLibraryVersion();
 
-			if ($adyenPaymentSource = $this->service->getClient()->getConfig()->getAdyenPaymentSource()) {
-				$params['applicationInfo']['adyenPaymentSource']['version'] = $adyenPaymentSource['version'];
-				$params['applicationInfo']['adyenPaymentSource']['name'] = $adyenPaymentSource['name'];
-			}
+        if ($adyenPaymentSource = $this->service->getClient()->getConfig()->getAdyenPaymentSource()) {
+            $params['applicationInfo']['adyenPaymentSource']['version'] = $adyenPaymentSource['version'];
+            $params['applicationInfo']['adyenPaymentSource']['name'] = $adyenPaymentSource['name'];
+        }
 
-			if ($externalPlatform = $this->service->getClient()->getConfig()->getExternalPlatform()) {
-				$params['applicationInfo']['externalPlatform']['version'] = $externalPlatform['version'];
-				$params['applicationInfo']['externalPlatform']['name'] = $externalPlatform['name'];
+        if ($externalPlatform = $this->service->getClient()->getConfig()->getExternalPlatform()) {
+            $params['applicationInfo']['externalPlatform']['version'] = $externalPlatform['version'];
+            $params['applicationInfo']['externalPlatform']['name'] = $externalPlatform['name'];
 
-				if (!empty($externalPlatform['integrator'])) {
-					$params['applicationInfo']['externalPlatform']['integrator'] = $externalPlatform['integrator'];
-				}
-			}
-
-            if ($merchantApplication = $this->service->getClient()->getConfig()->getMerchantApplication()) {
-                $params['applicationInfo']['merchantApplication']['version'] = $merchantApplication['version'];
-                $params['applicationInfo']['merchantApplication']['name'] = $merchantApplication['name'];
+            if (!empty($externalPlatform['integrator'])) {
+                $params['applicationInfo']['externalPlatform']['integrator'] = $externalPlatform['integrator'];
             }
+        }
 
-		} else {
-			// remove if exists
-			if (isset($params['applicationInfo'])) {
-				unset($params['applicationInfo']);
-			}
-		}
+        if ($merchantApplication = $this->service->getClient()->getConfig()->getMerchantApplication()) {
+            $params['applicationInfo']['merchantApplication']['version'] = $merchantApplication['version'];
+            $params['applicationInfo']['merchantApplication']['name'] = $merchantApplication['name'];
+        }
+
 
 		return $params;
 	}

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -160,9 +160,9 @@ abstract class AbstractResource
      * 3) Base64 encodes SaleToAcquirerData
      *
      * @param $params
-     * @return mixed
+     * @return array|null
      */
-    private function handleApplicationInfoInRequestPOS($params)
+    private function handleApplicationInfoInRequestPOS(array $params)
     {
         //If the POS request is not a payment request, do not add application info
         if (empty($params['SaleToPOIRequest']['PaymentRequest'])) {

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -141,6 +141,11 @@ abstract class AbstractResource
 				}
 			}
 
+            if ($merchantApplication = $this->service->getClient()->getConfig()->getMerchantApplication()) {
+                $params['applicationInfo']['merchantApplication']['version'] = $merchantApplication['version'];
+                $params['applicationInfo']['merchantApplication']['name'] = $merchantApplication['name'];
+            }
+
 		} else {
 			// remove if exists
 			if (isset($params['applicationInfo'])) {

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -28,7 +28,7 @@ abstract class AbstractResource
      * AbstractResource constructor.
      *
      * @param \Adyen\Service $service
-     * @param $endpoint
+     * @param string $endpoint
      * @param bool $allowApplicationInfo
      * @param bool $allowApplicationInfoPOS
      */

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -162,24 +162,32 @@ abstract class AbstractResource
      */
     private function handleApplicationInfoInRequestPOS($params)
     {
-        $saleToAcquirerData = $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'];
         //If the POS request is not a payment request, do not add application info
         if (empty($params['SaleToPOIRequest']['PaymentRequest'])) {
             return $params;
         }
 
-        //If SaleToAcquirerData is a querystring convert it to array
-        parse_str($saleToAcquirerData, $queryString);
-        $queryStringValues = array_values($queryString);
-        //check if querystring is nonempty and contains a value
-        if (!empty($queryString) && !empty($queryStringValues[0])) {
-            $saleToAcquirerData = $queryString;
+        // Initialize $saleToAcquirerData
+        $saleToAcquirerData = array();
+
+        if (!empty($params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'])) {
+            $saleToAcquirerData = $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'];
+
+            //If SaleToAcquirerData is a querystring convert it to array
+            parse_str($saleToAcquirerData, $queryString);
+            $queryStringValues = array_values($queryString);
+
+            //check if querystring is nonempty and contains a value
+            if (!empty($queryString) && !empty($queryStringValues[0])) {
+                $saleToAcquirerData = $queryString;
+            }
+
+            //If SaleToAcquirerData is a base64encoded string decode it and convert it to array
+            elseif ($this->isBase64Encoded($saleToAcquirerData)) {
+                $saleToAcquirerData = json_decode(base64_decode($saleToAcquirerData, true), true);
+            }
         }
 
-        //If SaleToAcquirerData is a base64encoded string decode it and convert it to array
-        elseif ($this->isBase64Encoded($saleToAcquirerData)){
-            $saleToAcquirerData = json_decode(base64_decode($saleToAcquirerData, true), true);
-        }
         //add Application Information
         $saleToAcquirerData = $this->handleApplicationInfoInRequest($saleToAcquirerData);
         $saleToAcquirerData = base64_encode(json_encode($saleToAcquirerData));

--- a/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
+++ b/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
@@ -9,6 +9,20 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 	 */
 	protected $endpoint;
 
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfoPOS = true;
+
 	/**
 	 * TerminalCloudAPI constructor.
 	 *
@@ -22,6 +36,6 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 		} else {
 			$this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/sync';
 		}
-		parent::__construct($service, $this->endpoint);
+		parent::__construct($service, $this->endpoint, $allowApplicationInfo = false, $this->allowApplicationInfoPOS);
 	}
 }

--- a/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
+++ b/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
@@ -36,6 +36,6 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 		} else {
 			$this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/sync';
 		}
-		parent::__construct($service, $this->endpoint, $allowApplicationInfo = false, $this->allowApplicationInfoPOS);
+		parent::__construct($service, $this->endpoint, $this->allowApplicationInfo, $this->allowApplicationInfoPOS);
 	}
 }

--- a/tests/PosPaymentTest.php
+++ b/tests/PosPaymentTest.php
@@ -9,7 +9,7 @@ class PosPaymentTest extends TestCase
 
     public function testCreatePosPaymentSuccess()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -74,7 +74,7 @@ class PosPaymentTest extends TestCase
     public function testCreatePosPaymentDeclined()
     {
 
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -138,7 +138,7 @@ class PosPaymentTest extends TestCase
 
     public function testCreatePosEMVRefundSuccess()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -200,13 +200,190 @@ class PosPaymentTest extends TestCase
 
     }
 
+    public function testGetConnectedTerminals()
+    {
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Construct request
+        $json = '{
+                    "merchantAccount": "' . $this->settings['merchantAccount'] . '"
+                }';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        try {
+            $result = $service->getConnectedTerminals($params);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['uniqueTerminalIds']));
+    }
+
+    public function testCreatePosPaymentSuccessWithOneclickQuerystring()
+    {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
+            $this->skipTest("Skipped the test. Configure your POIID in the config");
+        }
+
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Construct request
+        $transactionType = \Adyen\TransactionType::NORMAL;
+        $serviceID = date("dHis");
+        $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
+
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . $this->getPOIID() . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . $serviceID . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickQuerystring",
+                                    "TimeStamp": "' . $timeStamper . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . $transactionType . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = http_build_query($recurringDetails);
+        try {
+            $result = $service->runTenderSync($params);
+            print_r($result);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['SaleToPOIResponse']));
+        $this->assertEquals('Success', $result['SaleToPOIResponse']['PaymentResponse']['Response']['Result']);
+        try {
+            $additionalResponse = json_decode(base64_decode($result['SaleToPOIResponse']['PaymentResponse']['Response']['AdditionalResponse']), true);
+            $this->assertNotNull($additionalResponse['additionalData']['recurring.recurringDetailReference']);
+        }
+        catch (\Exception $e){
+            $this->fail();
+        }
+
+    }
+
+    public function testCreatePosPaymentSuccessWithOneclickBase64()
+    {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
+            $this->skipTest("Skipped the test. Configure your POIID in the config");
+        }
+
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Construct request
+        $transactionType = \Adyen\TransactionType::NORMAL;
+        $serviceID = date("dHis");
+        $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
+
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . $this->getPOIID() . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . $serviceID . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickBase64",
+                                    "TimeStamp": "' . $timeStamper . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . $transactionType . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(301),
+            'recurringContract' => "ONECLICK"
+        );
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
+        try {
+            $result = $service->runTenderSync($params);
+            print_r($result);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['SaleToPOIResponse']));
+        $this->assertEquals('Success', $result['SaleToPOIResponse']['PaymentResponse']['Response']['Result']);
+        try {
+            $additionalResponse = json_decode(base64_decode($result['SaleToPOIResponse']['PaymentResponse']['Response']['AdditionalResponse']),
+                true);
+            $this->assertNotNull($additionalResponse['additionalData']['recurring.recurringDetailReference']);
+        } catch (\Exception $e) {
+            $this->fail();
+        }
+    }
+
     /**
      * After timeout, an Exception will be returned with code: CURLE_OPERATION_TIMEOUTED
      * @covers \Adyen\HttpClient\CurlClient::handleCurlError
      */
     public function testPosPaymentFailTimeout()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -268,28 +445,5 @@ class PosPaymentTest extends TestCase
 
     }
 
-    public function testGetConnectedTerminals()
-    {
-        // initialize client
-        $client = $this->createTerminalCloudAPIClient();
-
-        // initialize service
-        $service = new Service\PosPayment($client);
-
-        //Construct request
-        $json = '{
-                    "merchantAccount": "' . $this->settings['merchantAccount'] . '"
-                }';
-
-        $params = json_decode($json, true); //Create associative array for passing along
-
-        try {
-            $result = $service->getConnectedTerminals($params);
-        } catch (\Exception $e) {
-            $this->validateApiPermission($e);
-        }
-
-        $this->assertTrue(isset($result['uniqueTerminalIds']));
-    }
 
 }

--- a/tests/PosPaymentTest.php
+++ b/tests/PosPaymentTest.php
@@ -311,6 +311,9 @@ class PosPaymentTest extends TestCase
         // initialize service
         $service = new Service\PosPayment($client);
 
+        //Set merchantApplication
+        $client->setMerchantApplication("merchantPosApplication", "0.0.test");
+
         //Construct request
         $transactionType = \Adyen\TransactionType::NORMAL;
         $serviceID = date("dHis");

--- a/tests/PosPaymentTest.php
+++ b/tests/PosPaymentTest.php
@@ -284,7 +284,6 @@ class PosPaymentTest extends TestCase
         $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = http_build_query($recurringDetails);
         try {
             $result = $service->runTenderSync($params);
-            print_r($result);
         } catch (\Exception $e) {
             $this->validateApiPermission($e);
         }
@@ -361,7 +360,6 @@ class PosPaymentTest extends TestCase
         $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
         try {
             $result = $service->runTenderSync($params);
-            print_r($result);
         } catch (\Exception $e) {
             $this->validateApiPermission($e);
         }

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -164,4 +164,199 @@ class AbstractResourceTest extends TestCase
 		$this->assertArrayHasKey("externalPlatform", $result["applicationInfo"]);
 		$this->assertArrayNotHasKey("integrator", $result["applicationInfo"]["externalPlatform"]);
 	}
+
+	public function testHandleApplicationInfoInRequestPOSShouldAddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauth",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+
+    }
+
+    public function testHandleApplicationInfoInRequestPOSWithQueryStringSaleToAcquirerDataAddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickQuerystring",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+
+        // Add RecurringDetails using querystring
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = http_build_query($recurringDetails);
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+
+        // Base64 decode the result and verify if all fields are still present
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("recurringContract", $resultArray);
+        $this->assertArrayHasKey("shopperEmail", $resultArray);
+        $this->assertArrayHasKey("shopperReference", $resultArray);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+
+    }
+
+    public function testHandleApplicationInfoInRequestPOSWithBase64AddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickBase64",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+
+        // Add RecurringDetails using querystring
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+
+        // Base64 decode the result and verify if all fields are still present
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("recurringContract", $resultArray);
+        $this->assertArrayHasKey("shopperEmail", $resultArray);
+        $this->assertArrayHasKey("shopperReference", $resultArray);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+    }
 }

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -10,36 +10,6 @@ class AbstractResourceTest extends TestCase
 	private $className = "Adyen\Service\AbstractResource";
 
 	/**
-	 * If the allowApplicationInfo is false the applicationInfo key should be removed from the params
-	 *
-	 * @covers \Adyen\Service\AbstractResource::handleApplicationInfoInRequest
-	 */
-	public function testHandleApplicationInfoInRequestShouldRemoveApplicationInfoFromParams()
-	{
-		$params = array(
-			"applicationInfo" => array(
-				"adyenLibrary" => array(
-					"name" => "test",
-            		"version" => "test"
-				)
-			)
-		);
-
-		// Mock client without the Test ini settings
-		$mockedClient = $this->createClientWithoutTestIni();
-
-		// Mock abstract class with mocked client and $paramsToFilter parameters
-		$mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", false));
-
-		// Get private method as testable public method
-		$method = $this->getMethod($this->className, "handleApplicationInfoInRequest");
-
-		// Test against function
-		$result = $method->invokeArgs($mockedClass, array($params));
-		$this->assertArrayNotHasKey("applicationInfo", $result);
-	}
-
-	/**
 	 * If the allowApplicationInfo is true the applicationInfo Adyen Library should be overwritten with the real values
 	 *
 	 * @covers \Adyen\Service\AbstractResource::handleApplicationInfoInRequest

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -335,7 +335,7 @@ class AbstractResourceTest extends TestCase
             'recurringContract' => "ONECLICK"
         );
 
-        // Add RecurringDetails using querystring
+        // Add RecurringDetails using base64
         $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
 
         // Mock client without the Test ini settings


### PR DESCRIPTION
**Description**
Add applicationInfo for terminal API requests inside SaleToAcquirerData.
If SaleToAcquirerData is empty, just add ApplicationInfo and base64encode it.
If SaleToAcquirerData contains data, add ApplicationInfo to it.

**Tested scenarios**
1. SaleToAcquirerData empty -> SaleToAcquirerData contains ApplicationInfo in base64
2. SaleToAcquirerData contains recurring details in querystring form -> SaleToAcquirerData contains recurring details and ApplicationInfo in Base64
3. SaleToAcquirerData contains recurring details in Base64 -> SaleToAcquirerData contains recurring details and ApplicationInfo in Base64

**Fixed issue**:  <!-- #-prefixed issue number -->
