### PR TITLE
Release 5.0.1

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -223,6 +223,17 @@ class Client
     }
 
     /**
+     * Set merchant application name and version
+     *
+     * @param string $name
+     * @param string $version
+     */
+    public function setMerchantApplication($name, $version)
+    {
+        $this->config->set('merchantApplication', array('name' => $name, 'version' => $version));
+    }
+
+    /**
      * Type can be json or array
      *
      * @param $value

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 
 class Client
 {
-    const LIB_VERSION = "5.0.0";
+    const LIB_VERSION = "5.0.1";
     const LIB_NAME = "adyen-php-api-library";
     const USER_AGENT_SUFFIX = "adyen-php-api-library/";
     const ENDPOINT_TEST = "https://pal-test.adyen.com";

--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -150,6 +150,14 @@ class Config implements ConfigInterface
 		return isset($this->data['adyenPaymentSource']) ? $this->data['adyenPaymentSource'] : null;
 	}
 
+    /**
+     * @return array|null an array with 'name' and 'version'
+     */
+    public function getMerchantApplication()
+    {
+        return isset($this->data['merchantApplication']) ? $this->data['merchantApplication'] : null;
+    }
+
 	/**
 	 * @return mixed|null
 	 */

--- a/src/Adyen/ConfigInterface.php
+++ b/src/Adyen/ConfigInterface.php
@@ -2,6 +2,11 @@
 
 namespace Adyen;
 
+/**
+ * Interface ConfigInterface
+ * @deprecated Please do not use your own interface as we will deprecate this in the future for improvements on the library
+ * @package Adyen
+ */
 Interface ConfigInterface
 {
 

--- a/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
+++ b/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
@@ -9,6 +9,20 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 	 */
 	protected $endpoint;
 
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfoPOS = true;
+
 	/**
 	 * TerminalCloudAPI constructor.
 	 *
@@ -22,6 +36,6 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 		} else {
 			$this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/sync';
 		}
-		parent::__construct($service, $this->endpoint);
+		parent::__construct($service, $this->endpoint, $this->allowApplicationInfo, $this->allowApplicationInfoPOS);
 	}
 }

--- a/tests/PosPaymentTest.php
+++ b/tests/PosPaymentTest.php
@@ -9,7 +9,7 @@ class PosPaymentTest extends TestCase
 
     public function testCreatePosPaymentSuccess()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -74,7 +74,7 @@ class PosPaymentTest extends TestCase
     public function testCreatePosPaymentDeclined()
     {
 
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -138,7 +138,7 @@ class PosPaymentTest extends TestCase
 
     public function testCreatePosEMVRefundSuccess()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -200,13 +200,191 @@ class PosPaymentTest extends TestCase
 
     }
 
+    public function testGetConnectedTerminals()
+    {
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Construct request
+        $json = '{
+                    "merchantAccount": "' . $this->settings['merchantAccount'] . '"
+                }';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        try {
+            $result = $service->getConnectedTerminals($params);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['uniqueTerminalIds']));
+    }
+
+    public function testCreatePosPaymentSuccessWithOneclickQuerystring()
+    {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
+            $this->skipTest("Skipped the test. Configure your POIID in the config");
+        }
+
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Construct request
+        $transactionType = \Adyen\TransactionType::NORMAL;
+        $serviceID = date("dHis");
+        $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
+
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . $this->getPOIID() . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . $serviceID . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickQuerystring",
+                                    "TimeStamp": "' . $timeStamper . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . $transactionType . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = http_build_query($recurringDetails);
+        try {
+            $result = $service->runTenderSync($params);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['SaleToPOIResponse']));
+        $this->assertEquals('Success', $result['SaleToPOIResponse']['PaymentResponse']['Response']['Result']);
+        try {
+            $additionalResponse = json_decode(base64_decode($result['SaleToPOIResponse']['PaymentResponse']['Response']['AdditionalResponse']), true);
+            $this->assertNotNull($additionalResponse['additionalData']['recurring.recurringDetailReference']);
+        }
+        catch (\Exception $e){
+            $this->fail();
+        }
+
+    }
+
+    public function testCreatePosPaymentSuccessWithOneclickBase64()
+    {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
+            $this->skipTest("Skipped the test. Configure your POIID in the config");
+        }
+
+        // initialize client
+        $client = $this->createTerminalCloudAPIClient();
+        // initialize service
+        $service = new Service\PosPayment($client);
+
+        //Set merchantApplication
+        $client->setMerchantApplication("merchantPosApplication", "0.0.test");
+
+        //Construct request
+        $transactionType = \Adyen\TransactionType::NORMAL;
+        $serviceID = date("dHis");
+        $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
+
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . $this->getPOIID() . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . $serviceID . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickBase64",
+                                    "TimeStamp": "' . $timeStamper . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . $transactionType . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(301),
+            'recurringContract' => "ONECLICK"
+        );
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
+        try {
+            $result = $service->runTenderSync($params);
+        } catch (\Exception $e) {
+            $this->validateApiPermission($e);
+        }
+
+        $this->assertTrue(isset($result['SaleToPOIResponse']));
+        $this->assertEquals('Success', $result['SaleToPOIResponse']['PaymentResponse']['Response']['Result']);
+        try {
+            $additionalResponse = json_decode(base64_decode($result['SaleToPOIResponse']['PaymentResponse']['Response']['AdditionalResponse']),
+                true);
+            $this->assertNotNull($additionalResponse['additionalData']['recurring.recurringDetailReference']);
+        } catch (\Exception $e) {
+            $this->fail();
+        }
+    }
+
     /**
      * After timeout, an Exception will be returned with code: CURLE_OPERATION_TIMEOUTED
      * @covers \Adyen\HttpClient\CurlClient::handleCurlError
      */
     public function testPosPaymentFailTimeout()
     {
-        if (empty($this->settings['POIID']) || $this->settings['POIID'] = 'UNIQUETERMINALID') {
+        if (empty($this->settings['POIID']) || $this->settings['POIID'] == 'UNIQUETERMINALID') {
             $this->skipTest("Skipped the test. Configure your POIID in the config");
         }
 
@@ -268,28 +446,5 @@ class PosPaymentTest extends TestCase
 
     }
 
-    public function testGetConnectedTerminals()
-    {
-        // initialize client
-        $client = $this->createTerminalCloudAPIClient();
-
-        // initialize service
-        $service = new Service\PosPayment($client);
-
-        //Construct request
-        $json = '{
-                    "merchantAccount": "' . $this->settings['merchantAccount'] . '"
-                }';
-
-        $params = json_decode($json, true); //Create associative array for passing along
-
-        try {
-            $result = $service->getConnectedTerminals($params);
-        } catch (\Exception $e) {
-            $this->validateApiPermission($e);
-        }
-
-        $this->assertTrue(isset($result['uniqueTerminalIds']));
-    }
 
 }

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -10,36 +10,6 @@ class AbstractResourceTest extends TestCase
 	private $className = "Adyen\Service\AbstractResource";
 
 	/**
-	 * If the allowApplicationInfo is false the applicationInfo key should be removed from the params
-	 *
-	 * @covers \Adyen\Service\AbstractResource::handleApplicationInfoInRequest
-	 */
-	public function testHandleApplicationInfoInRequestShouldRemoveApplicationInfoFromParams()
-	{
-		$params = array(
-			"applicationInfo" => array(
-				"adyenLibrary" => array(
-					"name" => "test",
-            		"version" => "test"
-				)
-			)
-		);
-
-		// Mock client without the Test ini settings
-		$mockedClient = $this->createClientWithoutTestIni();
-
-		// Mock abstract class with mocked client and $paramsToFilter parameters
-		$mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", false));
-
-		// Get private method as testable public method
-		$method = $this->getMethod($this->className, "handleApplicationInfoInRequest");
-
-		// Test against function
-		$result = $method->invokeArgs($mockedClass, array($params));
-		$this->assertArrayNotHasKey("applicationInfo", $result);
-	}
-
-	/**
 	 * If the allowApplicationInfo is true the applicationInfo Adyen Library should be overwritten with the real values
 	 *
 	 * @covers \Adyen\Service\AbstractResource::handleApplicationInfoInRequest
@@ -164,4 +134,199 @@ class AbstractResourceTest extends TestCase
 		$this->assertArrayHasKey("externalPlatform", $result["applicationInfo"]);
 		$this->assertArrayNotHasKey("integrator", $result["applicationInfo"]["externalPlatform"]);
 	}
+
+	public function testHandleApplicationInfoInRequestPOSShouldAddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauth",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+
+    }
+
+    public function testHandleApplicationInfoInRequestPOSWithQueryStringSaleToAcquirerDataAddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickQuerystring",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+
+        // Add RecurringDetails using querystring
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = http_build_query($recurringDetails);
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+
+        // Base64 decode the result and verify if all fields are still present
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("recurringContract", $resultArray);
+        $this->assertArrayHasKey("shopperEmail", $resultArray);
+        $this->assertArrayHasKey("shopperReference", $resultArray);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+
+    }
+
+    public function testHandleApplicationInfoInRequestPOSWithBase64AddBase64EncodedApplicationInfo()
+    {
+        $json = '{
+                    "SaleToPOIRequest": {
+                        "MessageHeader": {
+                            "MessageType": "Request",
+                            "MessageClass": "Service",
+                            "MessageCategory": "Payment",
+                            "SaleID": "PosTestLibrary",
+                            "POIID": "' . "POS-432123" . '",
+                            "ProtocolVersion": "3.0",
+                            "ServiceID": "' . "serviceID" . '"
+                        },
+                        "PaymentRequest": {
+                            "SaleData": {
+                                "SaleTransactionID": {
+                                    "TransactionID": "POSauthWithOneclickBase64",
+                                    "TimeStamp": "' . "time" . '"
+                                },
+                                "TokenRequestedType": "Customer",
+                                "SaleReferenceID": "SalesRefABC"
+                            },
+                            "PaymentTransaction": {
+                                "AmountsReq": {
+                                    "Currency": "EUR",
+                                    "RequestedAmount": ' . 14.91 . '
+                                }
+                            },
+                            "PaymentData": {
+                                "PaymentType": "' . \Adyen\TransactionType::NORMAL . '"
+                            }
+                        }
+                    }
+                }
+            ';
+
+        $params = json_decode($json, true); //Create associative array for passing along
+
+        $recurringDetails = array(
+            'shopperEmail' => "save@oneclick.card",
+            'shopperReference' => strval(300),
+            'recurringContract' => "ONECLICK"
+        );
+
+        // Add RecurringDetails using base64
+        $params['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData'] = base64_encode(json_encode($recurringDetails));
+
+        // Mock client without the Test ini settings
+        $mockedClient = $this->createClientWithoutTestIni();
+
+        // Mock abstract class with mocked client and $paramsToFilter parameters
+        $mockedClass = $this->getMockForAbstractClass($this->className, array((new \Adyen\Service($mockedClient)), "", true));
+
+        // Get private method as testable public method
+        $method = $this->getMethod($this->className, "handleApplicationInfoInRequestPOS");
+
+        // Test against function
+        $result = $method->invokeArgs($mockedClass, array($params));
+
+        // Base64 decode the result and verify if all fields are still present
+        $resultDecoded = base64_decode($result['SaleToPOIRequest']['PaymentRequest']['SaleData']['SaleToAcquirerData']);
+        $resultArray = json_decode($resultDecoded,true);
+        $this->assertArrayHasKey("recurringContract", $resultArray);
+        $this->assertArrayHasKey("shopperEmail", $resultArray);
+        $this->assertArrayHasKey("shopperReference", $resultArray);
+        $this->assertArrayHasKey("applicationInfo", $resultArray);
+        $this->assertArrayHasKey("adyenLibrary", $resultArray['applicationInfo']);
+    }
 }


### PR DESCRIPTION
* PW-1188 Add applicationInfo into terminal API requests

* PW-1188: add e2e tests

* PW-1188 add unittests, remove printlines from e2e tests

* PW-1188 more defensive in case SaleToAcquirerData is not defined

* fix comment on unittest

* PW-1188: add merchantApplication field to applicationInfo, add it to POS e2e test

* PW-1188 refactor

* Update src/Adyen/Service/AbstractResource.php

Co-Authored-By: Marcos Garcia <marcos.asgarcia@gmail.com>

* PW-1188 refactor

* fix using the right parameter for $allowApplicationInfo and deprecate interface as deprecated so we can remove it in future releases to cleanup the config object.

Co-authored-by: Marcos Garcia <marcos.asgarcia@gmail.com>
Co-authored-by: Rik ter Beek <rikterbeek@users.noreply.github.com>

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
