### PR TITLE
Fix bad phpdoc typehint for $liveEndpointUrlPrefix argument

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -124,7 +124,7 @@ class Client
      * For live please specify the unique identifier.
      *
      * @param string $environment
-     * @param null $liveEndpointUrlPrefix Provide the unique live url prefix from the "API URLs and Response" menu in the Adyen Customer Area
+     * @param string|null $liveEndpointUrlPrefix Provide the unique live url prefix from the "API URLs and Response" menu in the Adyen Customer Area
      * @throws AdyenException
      */
     public function setEnvironment($environment, $liveEndpointUrlPrefix = null)


### PR DESCRIPTION
**Description**
Argument `$liveEndpointUrlPrefix` has a wrong PHPDoc type hint `null`, whereas `string|null` is expected in the code.

**Fixed issue**:  Static analysis tools, such as PHPStan or Phan, rely on PHPDoc and fail due to wrong type hint.
