### PR TITLE
Improve Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,26 @@
+$script = <<-SCRIPT
+sudo yum install epel-release yum-utils -y
+sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm -y
+sudo yum-config-manager --enable remi-php73
+sudo yum install unzip wget php php-common php-opcache php-mcrypt php-cli php-curl php-xml php-mbstring -y
+cd /home/vagrant/adyen-php-api-library
+echo "Installing composer"
+sh bin/composer-installer.sh
+if [ $? -ne 0 ]
+    then
+        echo "Failed installing composer"
+        exit 1
+    else
+        echo "Composer installed successfully"
+        sudo mv composer.phar /bin/composer
+        sudo chmod a+x /bin/composer
+        composer install
+fi
+SCRIPT
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/bionic64"
-  config.vm.box_version = "1.0.282"
+  config.vm.box = "centos/7"
+  config.vm.synced_folder '.', '/home/vagrant/adyen-php-api-library', disabled: false
+  config.vm.network :forwarded_port, guest:3000, host: 3000
+  config.vm.provision "shell", inline: $script
 end

--- a/bin/composer-installer.sh
+++ b/bin/composer-installer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
This automates the `vagrant up` command by provisioning required packages and dependencies, and installing them on a provisioning run.

The `bin/composer-installer.sh` file is a recommended automation found in getcomposer.org. It downloads the sha-key for validation from the GitHub repository and downloads the composer.phar from the main location. This ensures a more secure download.
