### PR TITLE
Disable the default vagrant folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ SCRIPT
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
   config.vm.synced_folder '.', '/home/vagrant/adyen-php-api-library', disabled: false
+  config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.network :forwarded_port, guest:3000, host: 3000
   config.vm.provision "shell", inline: $script
 end


### PR DESCRIPTION
The /vagrant folder is write-protected in CentOS. This configuration prevents PHPStorm of trying to access it to run tests or other configuration.
