### PR TITLE
Add PHP 7.4 to Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
     - php: 7.2
     # aliased to a recent 7.3 version
     - php: 7.3
+    # aliased to a recent 7.4 version
+    - php: 7.4
       env:
         - COMPOSER_INSTALL=1
         - TEST=1


### PR DESCRIPTION
PHP 7.4 was released in December. This change raises awareness on compatibility issues.
