### PR TITLE
PSP Reference Search URL Generator

### DIFF
--- a/src/Adyen/Util/Util.php
+++ b/src/Adyen/Util/Util.php
@@ -205,7 +205,7 @@ class Util
      * @param string $checkoutEnvironment
      * @return string
      */
-    public function getPspReferenceSearchUrl($pspReference, $checkoutEnvironment)
+    public static function getPspReferenceSearchUrl($pspReference, $checkoutEnvironment)
     {
 
         return sprintf(

--- a/src/Adyen/Util/Util.php
+++ b/src/Adyen/Util/Util.php
@@ -197,4 +197,22 @@ class Util
 
         return $expectedSign == $merchantSign;
     }
+
+    /**
+     * Get the Customer Area PSP Search URL with a preset PSP Reference
+     *
+     * @param string $pspReference
+     * @param string $checkoutEnvironment
+     * @return string
+     */
+    public function getPspReferenceSearchUrl($pspReference, $checkoutEnvironment)
+    {
+
+        return sprintf(
+            "https://ca-%s.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=%s",
+            $checkoutEnvironment,
+            $pspReference
+        );
+
+    }
 }

--- a/tests/Util/UtilTest.php
+++ b/tests/Util/UtilTest.php
@@ -71,4 +71,33 @@ class UtilTest extends \PHPUnit\Framework\TestCase
         $hmacValidate = Util::isValidNotificationHMAC($params, $key);
         $this->assertTrue($hmacValidate);
     }
+
+    /**
+     * @param string $expectedResult
+     * @param string $pspReference
+     * @param string $checkoutEnvironment
+     * @dataProvider checkoutEnvironmentsProvider
+     *
+     */
+    public function testGetPspReferenceSearchUrl($expectedResult, $pspReference, $checkoutEnvironment)
+    {
+        $pspSearchUrl = Util::getPspReferenceSearchUrl($pspReference, $checkoutEnvironment);
+        $this->assertEquals($expectedResult, $pspSearchUrl);
+    }
+
+    public static function checkoutEnvironmentsProvider()
+    {
+        return array(
+            array(
+                'https://ca-live.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=7914073381342284',
+                '7914073381342284',
+                'live'
+            ),
+            array(
+                'https://ca-test.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=883580976999434D',
+                '883580976999434D',
+                'test'
+            )
+        );
+    }
 }


### PR DESCRIPTION
**Description**
We're starting to link the PSP reference to the CA search results page for easy query. This function has been added to the library now.

**Tested scenarios**
Live and Test PSP references in Magento 2 Notifications Overview and Notification Messages