### PR TITLE
Change monolog requirement for conflict with Laravel, fixes #173

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.3",
-    "monolog/monolog": "~1.16"
+    "monolog/monolog": ">=1.16"
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "0.2.0",


### PR DESCRIPTION
**Description**
Revert monolog dependency change to >=1.16

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  #173 
