### PR TITLE
remove duplicated classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,7 @@
   "autoload": {
     "psr-4": {
       "Adyen\\": "src/Adyen/"
-    },
-    "classmap": [
-      "src/Adyen/Service/"
-    ]
+    }
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
**Description**
this folder is already mapped by PSR-4, classmap is useless

**Tested scenarios**
autoloading continue to load files from `src/Adyen/Service/`

**Fixed issue**:  none
