### PR TITLE
fix client types declarations

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -2,6 +2,8 @@
 
 namespace Adyen;
 
+use Adyen\HttpClient\ClientInterface;
+use Adyen\HttpClient\CurlClient;
 use Psr\Log\LoggerInterface;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
@@ -41,32 +43,32 @@ class Client
     const ENDPOINT_DISPUTE_SERVICE_LIVE = "https://ca-live.adyen.com/ca/services/DisputeService";
 
     /**
-     * @var \Adyen\Config $config
+     * @var Config|ConfigInterface
      */
     private $config;
 
     /**
-     * @var
+     * @var ClientInterface|null
      */
     private $httpClient;
 
     /**
-     * @var Logger $logger
+     * @var LoggerInterface|null
      */
     private $logger;
 
     /**
      * Client constructor.
      *
-     * @param null $config
+     * @param ConfigInterface|null $config
      * @throws AdyenException
      */
     public function __construct($config = null)
     {
-        if (!$config) {
+        if ($config === null) {
             // create config
-            $this->config = new \Adyen\Config();
-        } elseif ($config instanceof \Adyen\ConfigInterface) {
+            $this->config = new Config();
+        } elseif ($config instanceof ConfigInterface) {
             $this->config = $config;
         } else {
             throw new \Adyen\AdyenException(
@@ -77,7 +79,7 @@ class Client
     }
 
     /**
-     * @return Config|ConfigInterface|null
+     * @return Config|ConfigInterface
      */
     public function getConfig()
     {
@@ -397,36 +399,36 @@ class Client
     }
 
     /**
-     * @param HttpClient\ClientInterface $httpClient
+     * @param ClientInterface $httpClient
      */
-    public function setHttpClient(\Adyen\HttpClient\ClientInterface $httpClient)
+    public function setHttpClient(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
     }
 
     /**
-     * @return mixed
+     * @return ClientInterface
      */
     public function getHttpClient()
     {
-        if (is_null($this->httpClient)) {
+        if ($this->httpClient === null) {
             $this->httpClient = $this->createDefaultHttpClient();
         }
         return $this->httpClient;
     }
 
     /**
-     * @return HttpClient\CurlClient
+     * @return CurlClient
      */
     protected function createDefaultHttpClient()
     {
-        return new \Adyen\HttpClient\CurlClient();
+        return new CurlClient();
     }
 
     /**
      * Set the Logger object
      *
-     * @param \Psr\Log\LoggerInterface $logger
+     * @param LoggerInterface $logger
      */
     public function setLogger(LoggerInterface $logger)
     {
@@ -434,12 +436,11 @@ class Client
     }
 
     /**
-     * @return Logger
-     * @throws \Exception
+     * @return LoggerInterface
      */
     public function getLogger()
     {
-        if (!isset($this->logger)) {
+        if ($this->logger === null) {
             $this->logger = $this->createDefaultLogger();
         }
 
@@ -448,7 +449,6 @@ class Client
 
     /**
      * @return Logger
-     * @throws \Exception
      */
     protected function createDefaultLogger()
     {


### PR DESCRIPTION
**Description**
fix types declaration and return types in `\Adyen\Client` for:
- $config
- $httpClient
- $logger

and relative getters/setters

**Tested scenarios**
none

**Fixed issue**:  none
