### PR TITLE
Add Code Coverage metrics to SonarCloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run test suite
-        run: vendor/bin/phpunit --testsuite=unit --coverage-clover build/clover.xml
+        run: vendor/bin/phpunit --testsuite=unit --coverage-clover build/clover.xml --log-junit build/tests-log.xml
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Run test suite
         run: vendor/bin/phpunit --testsuite=unit --coverage-clover build/clover.xml --log-junit build/tests-log.xml
 
+      # PHPUnit generates absolute file paths and SonarCloud expects relative file paths. This command removes the
+      # current working directory from the report files.
+      - name: Clean up reports
+        run: sed -i "s;`pwd`/;;g" build/*.xml
+
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@ sonar.organization=adyen
 sonar.projectKey=Adyen_adyen-php-api-library
 sonar.sources=.
 sonar.php.coverage.reportPaths=build/clover.xml
+sonar.php.tests.reportPath=build/tests-log.xml


### PR DESCRIPTION
**Description**
PHPUnit generates the Clover coverage files with absolute file paths, and I couldn't find a way to change that. So, instead, I set up a step in the Continuous Integration workflow to clean up the report files after it runs.

**Tested scenarios**
Code Coverage in SonarCloud with a short-lived branch.
