### PR TITLE
[PW-2385] Add check notification event code supports hmac.

### DIFF
--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -110,7 +110,7 @@ class HmacSignature
      */
     public function isHmacSupportedEventCode($response)
     {
-        $eventCodes = [
+        $eventCodes =  array(
             "ADVICE_OF_DEBIT",
             "AUTHORISATION",
             "AUTHORISATION_PENDING",
@@ -152,7 +152,7 @@ class HmacSignature
             "AUTHORISATION_ADJUSTMENT",
             "CANCEL_AUTORESCUE",
             "AUTORESCUE"
-        ];
+        );
         if (array_key_exists('eventCode', $response) && in_array($response['eventCode'], $eventCodes)) {
             return true;
         }

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -103,4 +103,59 @@ class HmacSignature
 
         return $expectedSign == $merchantSign;
     }
+    /**
+     * Returns true when the event code support HMAC validation
+     *
+     * @param $response
+     */
+    public function isHmacSupportedEventCode($response)
+    {
+        $eventCodes = [
+            "ADVICE_OF_DEBIT",
+            "AUTHORISATION",
+            "AUTHORISATION_PENDING",
+            "AUTHORISE_REFERRAL",
+            "CANCELLATION",
+            "CANCEL_OR_REFUND",
+            "CAPTURE",
+            "CAPTURE_FAILED",
+            "CAPTURE_WITH_EXTERNAL_AUTH",
+            "CHARGEBACK",
+            "CHARGEBACK_REVERSED",
+            "DEACTIVATE_RECURRING",
+            "FRAUD_ONLY",
+            "FUND_TRANSFER",
+            "HANDLED_EXTERNALLY",
+            "MANUAL_REVIEW_ACCEPT",
+            "NOTIFICATION_OF_CHARGEBACK",
+            "NOTIFICATION_OF_FRAUD",
+            "OFFER_CLOSED",
+            "ORDER_OPENED",
+            "PAIDOUT_REVERSED",
+            "PAYOUT_DECLINE",
+            "PAYOUT_EXPIRE",
+            "PAYOUT_THIRDPARTY",
+            "PREARBITRATION_LOST",
+            "PREARBITRATION_WON",
+            "PROCESS_RETRY",
+            "RECURRING_CONTRACT",
+            "REFUND",
+            "REFUNDED_REVERSED",
+            "REFUND_FAILED",
+            "REFUND_WITH_DATA",
+            "REQUEST_FOR_INFORMATION",
+            "SECOND_CHARGEBACK",
+            "SUBMIT_RECURRING",
+            "VOID_PENDING_REFUND",
+            "POSTPONED_REFUND",
+            "TECHNICAL_CANCEL",
+            "AUTHORISATION_ADJUSTMENT",
+            "CANCEL_AUTORESCUE",
+            "AUTORESCUE"
+        ];
+        if (array_key_exists('eventCode', $response) && in_array($response['eventCode'], $eventCodes)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -27,7 +27,7 @@ use Adyen\AdyenException;
 
 class HmacSignature
 {
-    const EVENTCODE = "eventCode";
+    const EVENT_CODE = "eventCode";
     /**
      * @param string $hmacKey Can be found in Customer Area
      * @param array $params The response from Adyen
@@ -70,7 +70,7 @@ class HmacSignature
         // `empty` treats too many value types as empty. `isset` should prevent some of these cases.
         $value = (isset($params['amount']['value'])) ? $params['amount']['value'] : "";
         $currency = (!empty($params['amount']['currency'])) ? $params['amount']['currency'] : "";
-        $eventCode = (!empty($params[self::EVENTCODE])) ? $params[self::EVENTCODE] : "";
+        $eventCode = (!empty($params[self::EVENT_CODE])) ? $params[self::EVENT_CODE] : "";
         $success = (!empty($params['success'])) ? $params['success'] : "";
 
         $dataToSign = array(
@@ -154,7 +154,7 @@ class HmacSignature
             "CANCEL_AUTORESCUE",
             "AUTORESCUE"
         );
-        if (array_key_exists(self::EVENTCODE, $response) && in_array($response[self::EVENTCODE], $eventCodes)) {
+        if (array_key_exists(self::EVENT_CODE, $response) && in_array($response[self::EVENT_CODE], $eventCodes)) {
             return true;
         }
         return false;

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -27,6 +27,7 @@ use Adyen\AdyenException;
 
 class HmacSignature
 {
+    const EVENTCODE = "eventCode";
     /**
      * @param string $hmacKey Can be found in Customer Area
      * @param array $params The response from Adyen
@@ -69,7 +70,7 @@ class HmacSignature
         // `empty` treats too many value types as empty. `isset` should prevent some of these cases.
         $value = (isset($params['amount']['value'])) ? $params['amount']['value'] : "";
         $currency = (!empty($params['amount']['currency'])) ? $params['amount']['currency'] : "";
-        $eventCode = (!empty($params['eventCode'])) ? $params['eventCode'] : "";
+        $eventCode = (!empty($params[self::EVENTCODE])) ? $params[self::EVENTCODE] : "";
         $success = (!empty($params['success'])) ? $params['success'] : "";
 
         $dataToSign = array(
@@ -153,7 +154,7 @@ class HmacSignature
             "CANCEL_AUTORESCUE",
             "AUTORESCUE"
         );
-        if (array_key_exists('eventCode', $response) && in_array($response['eventCode'], $eventCodes)) {
+        if (array_key_exists(self::EVENTCODE, $response) && in_array($response[self::EVENTCODE], $eventCodes)) {
             return true;
         }
         return false;

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -127,4 +127,22 @@ JSON
             $this->fail('Unexpected exception');
         }
     }
+
+    public function testisHmacSupportedEventCodeSuccess()
+    {
+        $params = json_decode('{
+	            "pspReference": "7914073381342284",
+	            "merchantAccountCode": "TestMerchant",
+	            "merchantReference": "TestPayment-1407325143704",
+	            "amount": {
+	                "value": 0,
+	                "currency": "EUR"
+	            },
+	            "eventCode": "AUTHORISATION",
+	            "success": "true"
+	        }', true);
+
+        $hmacSupportedEventCode = $hmac->isHmacSupportedEventCode($params);
+        $this->assertTrue($hmacSupportedEventCode);
+    }
 }

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -128,7 +128,7 @@ JSON
         }
     }
 
-    public function testisHmacSupportedEventCode()
+    public function testIsHmacSupportedEventCode()
     {
         $params = json_decode('{
 	            "pspReference": "7914073381342284",
@@ -142,7 +142,11 @@ JSON
 	            "success": "true"
 	        }', true);
         $hmac = new HmacSignature();
-        $hmacSupportedEventCode = $hmac->isHmacSupportedEventCode($params);
-        $this->assertTrue($hmacSupportedEventCode);
+        try {
+            $hmacSupportedEventCode = $hmac->isHmacSupportedEventCode($params);
+            $this->assertTrue($hmacSupportedEventCode);
+        } catch (AdyenException $e) {
+            $this->fail('Unexpected exception');
+        }
     }
 }

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -128,7 +128,7 @@ JSON
         }
     }
 
-    public function testisHmacSupportedEventCodeSuccess()
+    public function testisHmacSupportedEventCode()
     {
         $params = json_decode('{
 	            "pspReference": "7914073381342284",
@@ -141,7 +141,7 @@ JSON
 	            "eventCode": "AUTHORISATION",
 	            "success": "true"
 	        }', true);
-
+        $hmac = new HmacSignature();
         $hmacSupportedEventCode = $hmac->isHmacSupportedEventCode($params);
         $this->assertTrue($hmacSupportedEventCode);
     }


### PR DESCRIPTION
**Description**
Added the check isHmacSupportedEventCode to the library. This check returns true if the notification event code supports hmac calculation.

**Tested scenarios**
Add Unit test to test an existing event code in the list

