### PR TITLE
Add integration for paymentLinks under checkout API

### DIFF
--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -30,6 +30,11 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $paymentsDetails;
 
     /**
+     * @var ResourceModel\Checkout\PaymentLinks
+     */
+    protected $paymentLinks;
+
+    /**
      * Checkout constructor.
      *
      * @param \Adyen\Client $client
@@ -43,6 +48,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->paymentMethods = new \Adyen\Service\ResourceModel\Checkout\PaymentMethods($this);
         $this->payments = new \Adyen\Service\ResourceModel\Checkout\Payments($this);
         $this->paymentsDetails = new \Adyen\Service\ResourceModel\Checkout\PaymentsDetails($this);
+        $this->paymentLinks = new \Adyen\Service\ResourceModel\Checkout\PaymentLinks($this);
     }
 
     /**
@@ -100,5 +106,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     {
         $result = $this->paymentsDetails->request($params, $requestOptions);
         return $result;
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function paymentLinks($params, $requestOptions = null)
+    {
+        return $this->paymentLinks->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentLinks.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentLinks.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class PaymentLinks extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = true;
+
+    /**
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/paymentLinks';
+        parent::__construct($service, $this->endpoint, $this->allowApplicationInfo);
+    }
+}

--- a/tests/Resources/Checkout/payment-links-invalid.json
+++ b/tests/Resources/Checkout/payment-links-invalid.json
@@ -1,0 +1,6 @@
+{
+  "status": 422,
+  "errorCode": "130",
+  "message": "Reference Missing",
+  "errorType": "validation"
+}

--- a/tests/Resources/Checkout/payment-links-success.json
+++ b/tests/Resources/Checkout/payment-links-success.json
@@ -1,0 +1,9 @@
+{
+  "amount": {
+    "currency": "BRL",
+    "value": 1250
+  },
+  "expiresAt": "2020-06-30T08:23:18Z",
+  "reference": "YOUR_ORDER_NUMBER",
+  "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/payByLink.shtml?d=PL0A6D6846DB347E59"
+}

--- a/tests/Unit/CheckoutTest.php
+++ b/tests/Unit/CheckoutTest.php
@@ -315,4 +315,88 @@ class CheckoutTest extends TestCaseMock
             array('tests/Resources/Checkout/payments-result-success.json', 200)
         );
     }
+
+    /**
+     * @param string $jsonFile
+     * @param int $httpStatus
+     *
+     * @dataProvider successPaymentLinksProvider
+     */
+    public function testPaymentLinksSuccess($jsonFile, $httpStatus)
+    {
+        $client = $this->createMockClient($jsonFile, $httpStatus);
+
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            'merchantAccount' => "YourMerchantAccount",
+            'reference' => '12345',
+            'amount' => array('currency' => "BRL", 'value' => 1250),
+            'countryCode' => "BR",
+            'shopperReference' => "YourUniqueShopperId",
+            'shopperEmail' => "test@email.com",
+            'shopperLocale' => "pt_BR",
+            'billingAddress' => $this->getExampleAddressStruct(),
+            'deliveryAddress' => $this->getExampleAddressStruct(),
+        );
+
+        $result = $service->paymentLinks($params);
+
+        $this->assertStringContainsString('payByLink.shtml', $result['url']);
+    }
+
+    public static function successPaymentLinksProvider()
+    {
+        return array(
+            array('tests/Resources/Checkout/payment-links-success.json', 200),
+        );
+    }
+
+    /**
+     * @param string $jsonFile
+     * @param int $httpStatus
+     *
+     * @dataProvider invalidPaymentLinksProvider
+     */
+    public function testPaymentLinksInvalid($jsonFile, $httpStatus, $expectedExceptionMessage)
+    {
+        $client = $this->createMockClient($jsonFile, $httpStatus);
+
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            'merchantAccount' => "YourMerchantAccount",
+            'amount' => array('currency' => "BRL", 'value' => 1250),
+            'countryCode' => "BR",
+            'shopperReference' => "YourUniqueShopperId",
+            'shopperEmail' => "test@email.com",
+            'shopperLocale' => "pt_BR",
+            'billingAddress' => $this->getExampleAddressStruct(),
+            'deliveryAddress' => $this->getExampleAddressStruct(),
+        );
+
+        $this->expectException('Adyen\AdyenException');
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $service->paymentLinks($params);
+    }
+
+    public static function invalidPaymentLinksProvider()
+    {
+        return array(
+            array('tests/Resources/Checkout/payment-links-invalid.json', 422, 'Reference Missing'),
+        );
+    }
+
+    private function getExampleAddressStruct()
+    {
+        return array(
+            'street' => "Roque Petroni Jr",
+            'postalCode' => "59000060",
+            'city' => "São Paulo",
+            'houseNumberOrName' => "999",
+            'country' => "BR",
+            'stateOrProvince' => "SP",
+        );
+    }
 }


### PR DESCRIPTION
**Description**
Integration for `/paymentLinks` endpoint in Checkout service, in order to support programmatically creating a Pay By link URL as per https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v52/post/paymentLinks
