### PR TITLE
Require both ext-curl and ext-json in composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,11 @@
   "require": {
     "php": ">=5.6",
     "monolog/monolog": ">=1.16",
-    "ext-openssl": "*",
+    "ext-curl": "*",
     "ext-ctype": "*",
-    "ext-mbstring": "*"
+    "ext-json": "*",
+    "ext-mbstring": "*",
+    "ext-openssl": "*"
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "0.2.0",
@@ -20,7 +22,6 @@
     "phpunit/phpunit": "9.2.6",
     "php-coveralls/php-coveralls": "2.2.0",
     "squizlabs/php_codesniffer": "3.5.6",
-    "ext-json": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## The Problem

This package requires two PHP extensions which are not properly specified in the `composer.json`:
* ext-curl
* ext-json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adyen/adyen-php-api-library/221)
<!-- Reviewable:end -->
