### PR TITLE
Feature/add orders api support

### DIFF
--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -34,6 +34,10 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
      */
     protected $paymentLinks;
 
+    /**
+     * @var ResourceModel\Checkout\Orders
+     */
+    protected $orders;
 
     /**
      * @var ResourceModel\Checkout\PaymentMethodsBalance
@@ -55,6 +59,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->payments = new \Adyen\Service\ResourceModel\Checkout\Payments($this);
         $this->paymentsDetails = new \Adyen\Service\ResourceModel\Checkout\PaymentsDetails($this);
         $this->paymentLinks = new \Adyen\Service\ResourceModel\Checkout\PaymentLinks($this);
+        $this->orders = new \Adyen\Service\ResourceModel\Checkout\Orders($this);
         $this->paymentMethodsBalance = new \Adyen\Service\ResourceModel\Checkout\PaymentMethodsBalance($this);
     }
 
@@ -135,5 +140,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function paymentMethodsBalance($params, $requestOptions = null)
     {
         return $this->paymentMethodsBalance->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function orders($params, $requestOptions = null)
+    {
+        return $this->orders->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -34,6 +34,12 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
      */
     protected $paymentLinks;
 
+
+    /**
+     * @var ResourceModel\Checkout\PaymentMethodsBalance
+     */
+    protected $paymentMethodsBalance;
+
     /**
      * Checkout constructor.
      *
@@ -49,6 +55,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->payments = new \Adyen\Service\ResourceModel\Checkout\Payments($this);
         $this->paymentsDetails = new \Adyen\Service\ResourceModel\Checkout\PaymentsDetails($this);
         $this->paymentLinks = new \Adyen\Service\ResourceModel\Checkout\PaymentLinks($this);
+        $this->paymentMethodsBalance = new \Adyen\Service\ResourceModel\Checkout\PaymentMethodsBalance($this);
     }
 
     /**
@@ -117,5 +124,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function paymentLinks($params, $requestOptions = null)
     {
         return $this->paymentLinks->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function paymentMethodsBalance($params, $requestOptions = null)
+    {
+        return $this->paymentMethodsBalance->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -40,6 +40,11 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $orders;
 
     /**
+     * @var ResourceModel\Checkout\OrdersCancel
+     */
+    protected $ordersCancel;
+
+    /**
      * @var ResourceModel\Checkout\PaymentMethodsBalance
      */
     protected $paymentMethodsBalance;
@@ -60,6 +65,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->paymentsDetails = new \Adyen\Service\ResourceModel\Checkout\PaymentsDetails($this);
         $this->paymentLinks = new \Adyen\Service\ResourceModel\Checkout\PaymentLinks($this);
         $this->orders = new \Adyen\Service\ResourceModel\Checkout\Orders($this);
+        $this->ordersCancel = new \Adyen\Service\ResourceModel\Checkout\OrdersCancel($this);
         $this->paymentMethodsBalance = new \Adyen\Service\ResourceModel\Checkout\PaymentMethodsBalance($this);
     }
 
@@ -151,5 +157,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function orders($params, $requestOptions = null)
     {
         return $this->orders->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function ordersCancel($params, $requestOptions = null)
+    {
+        return $this->ordersCancel->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Checkout/Orders.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Orders.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class Orders extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Orders constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/orders';
+        parent::__construct($service, $this->endpoint);
+    }
+}

--- a/src/Adyen/Service/ResourceModel/Checkout/OrdersCancel.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/OrdersCancel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class OrdersCancel extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * OrdersCancel constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/orders/cancel';
+        parent::__construct($service, $this->endpoint);
+    }
+}

--- a/src/Adyen/Service/ResourceModel/Checkout/PaymentMethodsBalance.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/PaymentMethodsBalance.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class PaymentMethodsBalance extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * PaymentMethodsBalance constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/paymentMethods/balance';
+        parent::__construct($service, $this->endpoint);
+    }
+}

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -177,4 +177,26 @@ class CheckoutTest extends TestCase
         $this->assertEquals($result['resultCode'], 'Success');
         $this->assertEquals($result['balance']['value'], 100);
     }
+
+    public function testOrders()
+    {
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = [
+            'amount'          => [
+                'value'    => 2500,
+                'currency' => 'EUR',
+            ],
+            'merchantAccount' => $this->merchantAccount,
+            'reference'       => 'Your order number',
+        ];
+        $result = $service->orders($params);
+
+        $this->assertEquals($result['resultCode'], 'Success');
+        $this->assertEquals($result['remainingAmount']['value'], 2500);
+    }
 }

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -153,4 +153,28 @@ class CheckoutTest extends TestCase
         $secondResult = $service->payments($params, $requestOptions);
         $this->assertEquals($pspReference, $secondResult['pspReference']);
     }
+
+    public function testPaymentMethodsBalance()
+    {
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = [
+            'paymentMethod'   => [
+                'type'       => 'vvvgiftcard',
+                'number'     => '6064364240000000000',
+                'cvc'        => '737373',
+                'holderName' => 'balance EUR 100',
+            ],
+            'merchantAccount' => $this->merchantAccount,
+            'reference'       => 'Your order number',
+        ];
+        $result = $service->paymentMethodsBalance($params);
+
+        $this->assertEquals($result['resultCode'], 'Success');
+        $this->assertEquals($result['balance']['value'], 100);
+    }
 }


### PR DESCRIPTION
**Description**
- Added methods for checking the balance of giftcards using the paymentMethods/balance endpoint
- Added methods for for creating an order using the /orders endpoint
- Added methods for for cancelling an order using the /orders/cancel endpoint

**Tested scenarios**
- Tested to check balance
- Tested to create an order
- Tested to cancel an order

**Fixed issue**:  No issue attached
