### PR TITLE
[PW-2982] Upgrade checkout API endpoint from v52 to v64

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -22,7 +22,7 @@ class Client
     const API_BIN_LOOKUP_VERSION = "v50";
     const API_PAYOUT_VERSION = "v51";
     const API_RECURRING_VERSION = "v49";
-    const API_CHECKOUT_VERSION = "v52";
+    const API_CHECKOUT_VERSION = "v64";
     const API_CHECKOUT_UTILITY_VERSION = "v1";
     const API_NOTIFICATION_VERSION = "v5";
     const API_ACCOUNT_VERSION = "v5";

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -114,8 +114,8 @@ class CheckoutTest extends TestCase
             'paymentMethod' => array(
                 'type' => "scheme",
                 'number' => "4111111111111111",
-                'expiryMonth' => "08",
-                'expiryYear' => "2018",
+                'expiryMonth' => "03",
+                'expiryYear' => "2030",
                 'holderName' => "John Smith",
                 'cvc' => "737"
             ),
@@ -141,8 +141,8 @@ class CheckoutTest extends TestCase
             'paymentMethod' => array(
                 'type' => "scheme",
                 'number' => "4111111111111111",
-                'expiryMonth' => "08",
-                'expiryYear' => "2018",
+                'expiryMonth' => "03",
+                'expiryYear' => "2030",
                 'holderName' => "John Smith",
                 'cvc' => "737"
             ),

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -124,7 +124,7 @@ class CheckoutTest extends TestCase
         );
         $result = $service->payments($params);
 
-        $this->assertEquals($result['resultCode'], 'Authorised');
+        $this->assertEquals('Authorised', $result['resultCode']);
     }
 
     public function testPaymentsSuccessWithIdempotencyKey()
@@ -156,14 +156,12 @@ class CheckoutTest extends TestCase
         $requestOptions['idempotencyKey'] = $uuid;
 
         $result = $service->payments($params, $requestOptions);
-        $pspReference = $result['pspReference'];
 
-        $this->assertEquals($result['resultCode'], 'Authorised');
-
+        $this->assertEquals('Authorised', $result['resultCode']);
 
         // create the same request we expect the same pspreference response
         $secondResult = $service->payments($params, $requestOptions);
-        $this->assertEquals($pspReference, $secondResult['pspReference']);
+        $this->assertEquals($result['pspReference'], $secondResult['pspReference']);
     }
 
     public function testPaymentMethodsBalance()
@@ -186,8 +184,8 @@ class CheckoutTest extends TestCase
         ];
         $result = $service->paymentMethodsBalance($params);
 
-        $this->assertEquals($result['resultCode'], 'Success');
-        $this->assertEquals($result['balance']['value'], 100);
+        $this->assertEquals('Success', $result['resultCode']);
+        $this->assertEquals(100, $result['balance']['value']);
     }
 
     public function testOrders()
@@ -208,8 +206,8 @@ class CheckoutTest extends TestCase
         ];
         $result = $service->orders($params);
 
-        $this->assertEquals($result['resultCode'], 'Success');
-        $this->assertEquals($result['remainingAmount']['value'], 2500);
+        $this->assertEquals('Success', $result['resultCode']);
+        $this->assertEquals(2500, $result['remainingAmount']['value']);
         $this->pspReference = $result['pspReference'];
         $this->orderData    = $result['orderData'];
     }
@@ -236,6 +234,6 @@ class CheckoutTest extends TestCase
         ];
         $result = $service->ordersCancel($params);
 
-        $this->assertEquals($result['resultCode'], 'Received');
+        $this->assertEquals('Received', $result['resultCode']);
     }
 }

--- a/tests/Integration/CreatePaymentRequestTest.php
+++ b/tests/Integration/CreatePaymentRequestTest.php
@@ -45,8 +45,8 @@ class CreatePaymentRequestTest extends TestCase
         $json = '{
               "card": {
                 "number": "4111111111111111",
-                "expiryMonth": "08",
-                "expiryYear": "2018",
+                "expiryMonth": "03",
+                "expiryYear": "2030",
                 "cvc": "737",
                 "holderName": "John Smith"
               },
@@ -91,8 +91,8 @@ class CreatePaymentRequestTest extends TestCase
               },
               "card": {
                 "cvc": "737",
-                "expiryMonth": "08",
-                "expiryYear": "2018",
+                "expiryMonth": "03",
+                "expiryYear": "2030",
                 "holderName": "John Smith",
                 "number": "4111111111111111"
               },
@@ -136,8 +136,8 @@ class CreatePaymentRequestTest extends TestCase
         $json = '{
               "card": {
                 "number": "4111111111111111",
-                "expiryMonth": "08",
-                "expiryYear": "2018",
+                "expiryMonth": "03",
+                "expiryYear": "2030",
                 "cvc": "737",
                 "holderName": "John Smith"
               },
@@ -183,8 +183,8 @@ class CreatePaymentRequestTest extends TestCase
         $json = '{
               "card": {
                 "number": "4111111111111111",
-                "expiryMonth": "08",
-                "expiryYear": "2018",
+                "expiryMonth": "03",
+                "expiryYear": "2030",
                 "cvc": "737",
                 "holderName": "John Smith"
               },
@@ -231,8 +231,8 @@ class CreatePaymentRequestTest extends TestCase
         $json = '{
               "card": {
                 "number": "4111111111111111",
-                "expiryMonth": "08",
-                "expiryYear": "2018",
+                "expiryMonth": "03",
+                "expiryYear": "2030",
                 "cvc": "111",
                 "holderName": "John Smith"
               },


### PR DESCRIPTION
**Description**
Bump API_CHECKOUT_VERSION from v52 to v64

Important note
The update will break some implementations because fo the following new features of the new API version therefore when releasing this update a new major version needs to be released of the library.

 - Returns an error if unsupported fields (fields that are currently not in our API specifications) are provided in the payment request.
 - Pending is now the response type instead of PresentToShopper for both bcmc_mobile_QR and wechatpayQR
 - Added the configuration object to the /paymentMethods response for the API. Example can be found here: https://docs.adyen.com/api-explorer/#/CheckoutService/v64/post/paymentMethods__example_paymentMethods-basic (Click run to get the example response)
 - Now returns an error when sanitising invalid origin keys in the /payments flow.
 - Now returns an error when the length of the origin in the /payments request exceeds 80 characters.

**Fixed issue**:  <!-- #-prefixed issue number -->
#222 Update Checkout API version