### PR TITLE
make full adyen error code accessible in AdyenException

### DIFF
--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -22,6 +22,11 @@ class AdyenException extends Exception
     protected $pspReference;
 
     /**
+     * @var string
+     */
+    protected $adyenErrorCode;
+
+    /**
      * AdyenException constructor.
      *
      * @param string $message
@@ -30,6 +35,7 @@ class AdyenException extends Exception
      * @param string|null $status
      * @param string|null $errorType
      * @param string|null $pspReference
+     * @param string|null $adyenErrorCode
      */
     public function __construct(
         $message = "",
@@ -37,12 +43,14 @@ class AdyenException extends Exception
         Exception $previous = null,
         $status = null,
         $errorType = null,
-        $pspReference = null
+        $pspReference = null,
+        $adyenErrorCode = null
     ) {
         $this->status = $status;
         $this->errorType = $errorType;
         $this->pspReference = $pspReference;
-        parent::__construct($message, (int)$code, $previous);
+        $this->adyenErrorCode = $adyenErrorCode;
+        parent::__construct($message, $code, $previous);
     }
 
     /**
@@ -71,5 +79,13 @@ class AdyenException extends Exception
     public function getPspReference()
     {
         return $this->pspReference;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAdyenErrorCode()
+    {
+        return $this->adyenErrorCode;
     }
 }

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -309,11 +309,12 @@ class CurlClient implements ClientInterface
             $logger->error($decodeResult['errorCode'] . ': ' . $decodeResult['message']);
             throw new AdyenException(
                 $decodeResult['message'],
-                $decodeResult['errorCode'],
+                $decodeResult['status'],
                 null,
                 $decodeResult['status'],
                 $decodeResult['errorType'],
-                isset($decodeResult['pspReference']) ? $decodeResult['pspReference'] : null
+                isset($decodeResult['pspReference']) ? $decodeResult['pspReference'] : null,
+                $decodeResult['errorCode']
             );
         }
         $logger->error($result);

--- a/tests/Integration/ExceptionTest.php
+++ b/tests/Integration/ExceptionTest.php
@@ -107,7 +107,7 @@ class ExceptionTest extends TestCase
         // check if exception is correct
         $this->assertEquals(AdyenException::class, get_class($e));
         $this->assertEquals("HTTP Status Response - Unauthorized", $e->getMessage());
-        $this->assertEquals('0', $e->getCode());
+        $this->assertEquals('401', $e->getCode());
         $this->assertEquals('401', $e->getStatus());
     }
 }


### PR DESCRIPTION
**Description**
When an AdyenException was thrown (after a curl call to the Adyen API) in src/Adyen/HttpClient/CurlClient.php's handleResultError() method, the error code, returned from the API-Response, was not properly passed.

It was casted to an int and thus sometimes truncated.

**Fixed issue**:240
