### PR TITLE
Remove unsupported itemId from open invoice builder

### DIFF
--- a/src/Adyen/Service/Builder/OpenInvoice.php
+++ b/src/Adyen/Service/Builder/OpenInvoice.php
@@ -50,7 +50,6 @@ class OpenInvoice
         // item id is optional
         if (!empty($itemId)) {
             $lineItem['id'] = $itemId;
-            $lineItem['itemId'] = $itemId;
         }
 
         $lineItem['description'] = $description;

--- a/tests/Integration/Builder/OpenInvoiceTest.php
+++ b/tests/Integration/Builder/OpenInvoiceTest.php
@@ -32,7 +32,6 @@ class OpenInvoiceTest extends TestCase
     {
         $expectedResult = array(
             'id' => "1",
-            'itemId' => "1",
             'description' => "item-description",
             'amountExcludingTax' => 1000,
             'taxAmount' => 21,

--- a/tests/Integration/ExceptionTest.php
+++ b/tests/Integration/ExceptionTest.php
@@ -75,7 +75,7 @@ class ExceptionTest extends TestCase
         // check if exception is correct
         $this->assertEquals(AdyenException::class, get_class($e));
         $this->assertEquals('Invalid contract', $e->getMessage());
-        $this->assertEquals('802', $e->getCode());
+        $this->assertEquals('422', $e->getCode());
     }
 
     public function testExceptionMissingUsernamePassword()


### PR DESCRIPTION
**Description**
Remove unsupported itemId from open invoice builder since in the checkout API version 64 it's not supported anymore
