### PR TITLE
Provide wrapper for Hosted Onboarding Page (HOP) service

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -28,6 +28,7 @@ class Client
     const API_ACCOUNT_VERSION = "v5";
     const API_FUND_VERSION = "v5";
     const API_DISPUTE_SERVICE_VERSION = "v30";
+    const API_HOP_VERSION = "v6";
     const ENDPOINT_TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
     const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com/checkout";
@@ -43,6 +44,8 @@ class Client
     const ENDPOINT_DISPUTE_SERVICE_LIVE = "https://ca-live.adyen.com/ca/services/DisputeService";
     const ENDPOINT_CUSTOMER_AREA_TEST = "https://ca-test.adyen.com";
     const ENDPOINT_CUSTOMER_AREA_LIVE = "https://ca-live.adyen.com";
+    const ENDPOINT_HOP_TEST = "https://cal-test.adyen.com/cal/services/Hop";
+    const ENDPOINT_HOP_LIVE = "https://cal-live.adyen.com/cal/services/Hop";
 
     /**
      * @var Config|ConfigInterface
@@ -150,6 +153,7 @@ class Client
             $this->config->set('endpointFund', self::ENDPOINT_FUND_TEST);
             $this->config->set('endpointDisputeService', self::ENDPOINT_DISPUTE_SERVICE_TEST);
             $this->config->set('endpointCustomerArea', self::ENDPOINT_CUSTOMER_AREA_TEST);
+            $this->config->set('endpointHop', self::ENDPOINT_HOP_TEST);
         } elseif ($environment == \Adyen\Environment::LIVE) {
             $this->config->set('environment', \Adyen\Environment::LIVE);
             $this->config->set('endpointDirectorylookup', self::ENDPOINT_LIVE_DIRECTORY_LOOKUP);
@@ -159,6 +163,7 @@ class Client
             $this->config->set('endpointFund', self::ENDPOINT_FUND_LIVE);
             $this->config->set('endpointDisputeService', self::ENDPOINT_DISPUTE_SERVICE_LIVE);
             $this->config->set('endpointCustomerArea', self::ENDPOINT_CUSTOMER_AREA_LIVE);
+            $this->config->set('endpointHop', self::ENDPOINT_HOP_LIVE);
 
             if ($liveEndpointUrlPrefix) {
                 $this->config->set(
@@ -390,6 +395,16 @@ class Client
     public function getApiFundVersion()
     {
         return self::API_FUND_VERSION;
+    }
+
+    /**
+     * Get the version of the Hop API endpoint
+     *
+     * @return string
+     */
+    public function getApiHopVersion()
+    {
+        return self::API_HOP_VERSION;
     }
 
     /**

--- a/src/Adyen/Service/Hop.php
+++ b/src/Adyen/Service/Hop.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Adyen\Service;
+
+class Hop extends \Adyen\Service
+{
+
+    /**
+     * @var ResourceModel\Hop\GetOnboardingUrl
+     */
+    protected $getOnboardingUrl;
+
+    /**
+     * Hop constructor.
+     * @param \Adyen\Client $client
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct(\Adyen\Client $client)
+    {
+        parent::__construct($client);
+
+        $this->getOnboardingUrl = new \Adyen\Service\ResourceModel\Hop\GetOnboardingUrl($this);
+    }
+
+    /**
+     * @param $params
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function getOnboardingUrl($params)
+    {
+        return $this->getOnboardingUrl->request($params);
+    }
+}

--- a/src/Adyen/Service/ResourceModel/Hop/GetOnboardingUrl.php
+++ b/src/Adyen/Service/ResourceModel/Hop/GetOnboardingUrl.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Hop;
+
+class GetOnboardingUrl extends \Adyen\Service\AbstractResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * CreateAccount constructor.
+     * @param $service
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $service->getClient()->getConfig()->get('endpointHop') .
+            '/' . $service->getClient()->getApiHopVersion() . '/getOnboardingUrl';
+        parent::__construct($service, $this->endpoint);
+    }
+}

--- a/tests/Integration/HopTest.php
+++ b/tests/Integration/HopTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen API Library for PHP
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+namespace Adyen\Tests\Integration;
+
+use Adyen\Tests\TestCase;
+
+class HopTest extends TestCase
+{
+    public function testGetOnboardingUrl()
+    {
+        $client = $this->createClient();
+        $accountService = new \Adyen\Service\Account($client);
+        $hopService = new \Adyen\Service\Hop($client);
+
+        /* Test account holder for the HOP URL test */
+        $params = $this->getTestAccountHolder();
+
+        /*
+         * Look for an existing TestAccountHolder
+         * Otherwise create a new one for the test
+         */
+        try {
+            $accountService->getAccountHolder($params);
+        } catch (\Adyen\AdyenException $exception) {
+            $accountService->createAccountHolder($params);
+        }
+
+
+        /*
+         * Now we have an account holder, generate a HOP
+         * URL using the HopService which we are testing
+         */
+        $params = json_decode(
+            '{
+                "accountHolderCode":"TestAccountHolderCode2",
+                "returnUrl":"https://your.return-url.com/?submerchant=123",
+                "platformName":"MyShop.com"
+            }',
+            true
+        );
+
+        $result = $hopService->getOnboardingUrl($params);
+
+        /* Assert result was successful */
+        $this->assertEquals("Success", $result['resultCode']);
+    }
+
+    private function getTestAccountHolder()
+    {
+        return json_decode(
+            '
+            {
+              "accountHolderCode": "TestAccountHolderCode2",
+              "accountHolderDetails": {
+                "email": "john@doe.com",
+                "individualDetails": {
+                  "name": {
+                    "firstName": "John",
+                    "gender": "MALE",
+                    "lastName": "Doe"
+                  }
+                },
+                "address": {
+                  "country": "US"
+                }
+              },
+              "legalEntity": "Individual"
+            }',
+            true
+        );
+    }
+}

--- a/tests/Integration/HopTest.php
+++ b/tests/Integration/HopTest.php
@@ -33,7 +33,7 @@ class HopTest extends TestCase
         $accountService = new \Adyen\Service\Account($client);
         $hopService = new \Adyen\Service\Hop($client);
 
-        /* Test account holder for the HOP URL test */
+        /* Test account holder for the HOP getOnboardingUrl test */
         $params = $this->getTestAccountHolder();
 
         /*
@@ -53,7 +53,7 @@ class HopTest extends TestCase
          */
         $params = json_decode(
             '{
-                "accountHolderCode":"TestAccountHolderCode2",
+                "accountHolderCode":"TestAccountHolderCode",
                 "returnUrl":"https://your.return-url.com/?submerchant=123",
                 "platformName":"MyShop.com"
             }',
@@ -71,7 +71,7 @@ class HopTest extends TestCase
         return json_decode(
             '
             {
-              "accountHolderCode": "TestAccountHolderCode2",
+              "accountHolderCode": "TestAccountHolderCode",
               "accountHolderDetails": {
                 "email": "john@doe.com",
                 "individualDetails": {


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This Pull Request provides a wrapper for the Adyen Hosted Onboarding Page (HOP) service:
https://docs.adyen.com/api-explorer/#/Hop/v6/overview

Allows users of the library to generate HOP url for a provided account holder.

Example usage:

```
$client = new \Adyen\Client();
$client->setApplicationName("Adyen PHP Api Library Example");
$client->setUsername("YOUR USERNAME");
$client->setPassword("YOUR PASSWORD");
$client->setXApiKey("YOUR API KEY");
$client->setEnvironment(\Adyen\Environment::TEST);
$client->setTimeout(30);

// intialize HOP service
$service = new \Adyen\Service\Hop($client);

// required are accountHolderCode, returnUrl and platformName
$params = array(
    "accountHolderCode" => 'TestAccountHolderCode',
    "returnUrl" => 'https://your.return-url.com/?submerchant=123',
    "platformName" => 'MyShop.com'
);

$result = $service->getOnboardingUrl($params);
```

**Tested scenarios**
<!-- Description of tested scenarios -->
PHPUnit test is provided: HopTest
This tests full coverage of this PR - the ability to generate a HOP url for a given account holder. If the test account holder is not present it is created. Requires API credentials and is skipped if they are not provided.

**Fixed issue**:  <!-- #-prefixed issue number -->
New Feature
