### PR TITLE
[PW-2843] bug fix in check for notificationMode as string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/src/Adyen/Service/NotificationReceiver.php
+++ b/src/Adyen/Service/NotificationReceiver.php
@@ -115,15 +115,15 @@ class NotificationReceiver
     /**
      * Checks if notification mode and the store mode configuration matches
      *
-     * @param $notificationMode
-     * @param $testMode bool
+     * @param mixed $notificationMode
+     * @param bool $testMode
      * @return bool
      */
     public function validateNotificationMode($notificationMode, $testMode)
     {
         // Notification mode can be a string or a boolean
-        if (($testMode && ($notificationMode == 'false' || !$notificationMode)) ||
-            (!$testMode && ($notificationMode == 'true' || $notificationMode))
+        if (($testMode && ($notificationMode === 'false' || $notificationMode === false)) ||
+            (!$testMode && ($notificationMode === 'true' || $notificationMode === true))
         ) {
             return true;
         }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Bugfix in `validateNotificationMode`, if `$notificationMode` is passed as a string 'false' and `$testMode` is `false` then logic fails
**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
