### PR TITLE
[PW-3779] update checkout API version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -22,7 +22,7 @@ class Client
     const API_BIN_LOOKUP_VERSION = "v50";
     const API_PAYOUT_VERSION = "v51";
     const API_RECURRING_VERSION = "v49";
-    const API_CHECKOUT_VERSION = "v64";
+    const API_CHECKOUT_VERSION = "v66";
     const API_CHECKOUT_UTILITY_VERSION = "v1";
     const API_NOTIFICATION_VERSION = "v5";
     const API_ACCOUNT_VERSION = "v5";


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR updates the version of [checkout API](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/overview)
The update introduces breaking changes and would be released as a major release.
- All `shopperReference` values that are less than 3 characters long will now trigger a validation error.
- Merchants are no longer able to send a mix of both the `storePaymentMethod: true` and `enableRecurring`, `enableOneClick` fields in the same `/payments` request. A validation error will be thrown.
- The `paid` field in the `/paymentLinks` response now returns `completed` instead of `paid`
See other added features in [release notes](https://docs.adyen.com/online-payments/release-notes#nov-30th-2020)
**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
