### PR TITLE
Release 9.0.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @msilvagarcia @cyattilakiss @AlexandrosMor @acampos1916 @Aleffio @rikterbeek
+* @msilvagarcia @cyattilakiss @AlexandrosMor @acampos1916 @peterojo @Aleffio @rikterbeek

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @msilvagarcia @cyattilakiss @AlexandrosMor @acampos1916 @peterojo @Aleffio @rikterbeek
+* @msilvagarcia @cyattilakiss @AlexandrosMor @acampos1916 @peterojo @Aleffio @rikterbeek @morerice

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "0.2.1",
     "friendsofphp/php-cs-fixer": "*",
-    "phpunit/phpunit": "9.5.0",
+    "phpunit/phpunit": "9.5.1",
     "php-coveralls/php-coveralls": "2.4.2",
     "squizlabs/php_codesniffer": "3.5.8"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49332a8d9d06afabcbcfbe4142d0a4c1",
+    "content-hash": "e48dac2a88fcc0063f1d778af8170746",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -927,16 +927,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.3",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
                 "shasum": ""
             },
             "require": {
@@ -977,9 +977,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
             },
-            "time": "2020-12-03T17:45:45+00:00"
+            "time": "2020-12-20T10:01:03+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1043,16 +1043,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
                 "shasum": ""
             },
             "require": {
@@ -1088,9 +1088,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.3"
+                "source": "https://github.com/phar-io/version/tree/3.0.4"
             },
-            "time": "2020-11-30T09:21:21+00:00"
+            "time": "2020-12-13T23:18:30+00:00"
         },
         {
             "name": "php-coveralls/php-coveralls",
@@ -1386,16 +1386,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
@@ -1407,7 +1407,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -1447,9 +1447,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
             },
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1771,16 +1771,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.0",
+            "version": "9.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
+                "reference": "e7bdf4085de85a825f4424eae52c99a1cec2f360"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7bdf4085de85a825f4424eae52c99a1cec2f360",
+                "reference": "e7bdf4085de85a825f4424eae52c99a1cec2f360",
                 "shasum": ""
             },
             "require": {
@@ -1858,7 +1858,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.1"
             },
             "funding": [
                 {
@@ -1870,7 +1870,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-04T05:05:53+00:00"
+            "time": "2021-01-17T07:42:25+00:00"
         },
         {
             "name": "psr/container",
@@ -3743,16 +3743,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -3764,7 +3764,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3802,7 +3802,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
             },
             "funding": [
                 {
@@ -3818,7 +3818,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -10,7 +10,7 @@ use Monolog\Handler\StreamHandler;
 
 class Client
 {
-    const LIB_VERSION = "8.1.0";
+    const LIB_VERSION = "9.0.0";
     const LIB_NAME = "adyen-php-api-library";
     const USER_AGENT_SUFFIX = "adyen-php-api-library/";
     const ENDPOINT_TEST = "https://pal-test.adyen.com";

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -10,7 +10,7 @@ use Monolog\Handler\StreamHandler;
 
 class Client
 {
-    const LIB_VERSION = "8.0.0";
+    const LIB_VERSION = "8.1.0";
     const LIB_NAME = "adyen-php-api-library";
     const USER_AGENT_SUFFIX = "adyen-php-api-library/";
     const ENDPOINT_TEST = "https://pal-test.adyen.com";

--- a/src/Adyen/Service/Builder/OpenInvoice.php
+++ b/src/Adyen/Service/Builder/OpenInvoice.php
@@ -50,7 +50,6 @@ class OpenInvoice
         // item id is optional
         if (!empty($itemId)) {
             $lineItem['id'] = $itemId;
-            $lineItem['itemId'] = $itemId;
         }
 
         $lineItem['description'] = $description;

--- a/src/Adyen/Util/OpenInvoice.php
+++ b/src/Adyen/Util/OpenInvoice.php
@@ -29,15 +29,41 @@ class OpenInvoice
     const AFTERPAY_B2B_PAYMENT_METHOD = 'afterpay_b2b';
     const AFTERPAY_DEFAULT_PAYMENT_METHOD = 'afterpay_default';
     const AFTERPAY_DIRECTDEBIT_PAYMENT_METHOD = 'afterpay_directdebit';
-    const AFTERPAYTOUCH_PAYMENT_METHOD = 'afterpaytouch';
 
-    const RATEPAY_PAYMENT_METHOD = 'ratepay';
+    const AFTERPAYTOUCH = "afterpaytouch";
+    const AFTERPAYTOUCH_AU = "afterpaytouch_AU";
+    const AFTERPAYTOUCH_CA = "afterpaytouch_CA";
+    const AFTERPAYTOUCH_NZ = "afterpaytouch_NZ";
+    const AFTERPAYTOUCH_US = "afterpaytouch_US";
+
+    const RATEPAY = 'ratepay';
     const RATEPAY_DIRECTDEBIT_PAYMENT_METHOD = 'ratepay_directdebit';
 
     const KLARNA_PAYMENT_METHOD = 'klarna';
     const KLARNA_B2B_PAYMENT_METHOD = 'klarna_b2b';
     const KLARNA_PAYNOW_PAYMENT_METHOD = 'klarna_paynow';
     const KLARNA_ACCOUNT_PAYMENT_METHOD = 'klarna_account';
+
+    const FACILYPAY = 'facilypay';
+    const FACILYPAY_10X = 'facilypay_10x';
+    const FACILYPAY_10X_MERCHANT_PAYS = 'facilypay_10x_merchant_pays';
+    const FACILYPAY_10X_WITHFEES = 'facilypay_10x_withfees';
+    const FACILYPAY_12X = 'facilypay_12x';
+    const FACILYPAY_12X_MERCHANT_PAYS = 'facilypay_12x_merchant_pays';
+    const FACILYPAY_12X_WITHFEES = 'facilypay_12x_withfees';
+    const FACILYPAY_3X = 'facilypay_3x';
+    const FACILYPAY_3X_MERCHANT_PAYS = 'facilypay_3x_merchant_pays';
+    const FACILYPAY_3X_WITHFEES = 'facilypay_3x_withfees';
+    const FACILYPAY_4X = 'facilypay_4x';
+    const FACILYPAY_4X_MERCHANT_PAYS = 'facilypay_4x_merchant_pays';
+    const FACILYPAY_4X_WITHFEES = 'facilypay_4x_withfees';
+    const FACILYPAY_6X = 'facilypay_6x';
+    const FACILYPAY_6X_MERCHANT_PAYS = 'facilypay_6x_merchant_pays';
+    const FACILYPAY_6X_WITHFEES = 'facilypay_6x_withfees';
+    const FACILYPAY_FR = 'facilypay_fr';
+
+    const AFFIRM = 'affirm';
+    const CLEARPAY = 'clearpay';
 
     /**
      * List of open invoice payment methods
@@ -49,13 +75,49 @@ class OpenInvoice
         self::AFTERPAY_B2B_PAYMENT_METHOD,
         self::AFTERPAY_DEFAULT_PAYMENT_METHOD,
         self::AFTERPAY_DIRECTDEBIT_PAYMENT_METHOD,
-        self::AFTERPAYTOUCH_PAYMENT_METHOD,
-        self::RATEPAY_PAYMENT_METHOD,
+        self::AFTERPAYTOUCH,
+        self::AFTERPAYTOUCH_AU,
+        self::AFTERPAYTOUCH_CA,
+        self::AFTERPAYTOUCH_NZ,
+        self::AFTERPAYTOUCH_US,
+        self::RATEPAY,
         self::RATEPAY_DIRECTDEBIT_PAYMENT_METHOD,
         self::KLARNA_PAYMENT_METHOD,
         self::KLARNA_B2B_PAYMENT_METHOD,
         self::KLARNA_PAYNOW_PAYMENT_METHOD,
         self::KLARNA_ACCOUNT_PAYMENT_METHOD,
+        self::AFFIRM,
+        self::CLEARPAY,
+        self::FACILYPAY,
+        self::FACILYPAY_10X,
+        self::FACILYPAY_10X_MERCHANT_PAYS,
+        self::FACILYPAY_10X_WITHFEES,
+        self::FACILYPAY_12X,
+        self::FACILYPAY_12X_MERCHANT_PAYS,
+        self::FACILYPAY_12X_WITHFEES,
+        self::FACILYPAY_3X,
+        self::FACILYPAY_3X_MERCHANT_PAYS,
+        self::FACILYPAY_3X_WITHFEES,
+        self::FACILYPAY_4X,
+        self::FACILYPAY_4X_MERCHANT_PAYS,
+        self::FACILYPAY_4X_WITHFEES,
+        self::FACILYPAY_6X,
+        self::FACILYPAY_6X_MERCHANT_PAYS,
+        self::FACILYPAY_6X_WITHFEES,
+        self::FACILYPAY_FR,
+    );
+
+    /**
+     * List of after pay touch payment methods
+     *
+     * @var array
+     */
+    private static $afterPayTouchPaymentMethods = array(
+        self::AFTERPAYTOUCH,
+        self::AFTERPAYTOUCH_AU,
+        self::AFTERPAYTOUCH_CA,
+        self::AFTERPAYTOUCH_NZ,
+        self::AFTERPAYTOUCH_US,
     );
 
     /**
@@ -95,7 +157,7 @@ class OpenInvoice
      */
     public function isAfterPayTouchPaymentMethod($paymentMethod)
     {
-        if (self::AFTERPAYTOUCH_PAYMENT_METHOD === $paymentMethod) {
+        if (in_array($paymentMethod, self::$afterPayTouchPaymentMethods)) {
             return true;
         }
         return false;

--- a/tests/Integration/Builder/OpenInvoiceTest.php
+++ b/tests/Integration/Builder/OpenInvoiceTest.php
@@ -32,7 +32,6 @@ class OpenInvoiceTest extends TestCase
     {
         $expectedResult = array(
             'id' => "1",
-            'itemId' => "1",
             'description' => "item-description",
             'amountExcludingTax' => 1000,
             'taxAmount' => 21,

--- a/tests/Integration/ExceptionTest.php
+++ b/tests/Integration/ExceptionTest.php
@@ -75,7 +75,7 @@ class ExceptionTest extends TestCase
         // check if exception is correct
         $this->assertEquals(AdyenException::class, get_class($e));
         $this->assertEquals('Invalid contract', $e->getMessage());
-        $this->assertEquals('802', $e->getCode());
+        $this->assertEquals('422', $e->getCode());
     }
 
     public function testExceptionMissingUsernamePassword()

--- a/tests/Unit/Util/OpenInvoiceTest.php
+++ b/tests/Unit/Util/OpenInvoiceTest.php
@@ -44,12 +44,28 @@ class OpenInvoiceTest extends TestCase
         $this->assertTrue($result);
         $result = $openInvoice->isOpenInvoicePaymentMethod("wechat");
         $this->assertFalse($result);
+        $result = $openInvoice->isOpenInvoicePaymentMethod("affirm");
+        $this->assertTrue($result);
+        $result = $openInvoice->isOpenInvoicePaymentMethod("clearpay");
+        $this->assertTrue($result);
+        $result = $openInvoice->isOpenInvoicePaymentMethod("facilypay_10x");
+        $this->assertTrue($result);
+        $result = $openInvoice->isOpenInvoicePaymentMethod("facilypay");
+        $this->assertTrue($result);
     }
 
     public function testIsAfterPayTouchPaymentMethod()
     {
         $openInvoice = new OpenInvoice();
         $result = $openInvoice->isAfterPayTouchPaymentMethod("afterpaytouch");
+        $this->assertTrue($result);
+        $result = $openInvoice->isAfterPayTouchPaymentMethod("afterpaytouch_AU");
+        $this->assertTrue($result);
+        $result = $openInvoice->isAfterPayTouchPaymentMethod("afterpaytouch_CA");
+        $this->assertTrue($result);
+        $result = $openInvoice->isAfterPayTouchPaymentMethod("afterpaytouch_NZ");
+        $this->assertTrue($result);
+        $result = $openInvoice->isAfterPayTouchPaymentMethod("afterpaytouch_US");
         $this->assertTrue($result);
         $result = $openInvoice->isAfterPayTouchPaymentMethod("alipay");
         $this->assertFalse($result);


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
#245 Add Affirm and Clearpay as open invoice payment methods
#249 bug fix in check for notificationMode as string
#252 Update dependency phpunit/phpunit to v9.5.1
#254 Update checkout API version from v64 to v66

**Important note**
This update will bump the version of checkout API used and will introduce the following breaking changes.
- All `shopperReference` values that are less than 3 characters long will now trigger a validation error.
- Merchants are no longer able to send a mix of both the `storePaymentMethod: true` and `enableRecurring`, `enableOneClick` fields in the same `/payments` request. A validation error will be thrown.
- The `paid` field in the `/paymentLinks` response now returns `completed` instead of `paid`
See other added features in [release notes](https://docs.adyen.com/online-payments/release-notes#nov-30th-2020)
