### PR TITLE
Keep error code the same for backwards compatibility

### DIFF
--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -50,7 +50,7 @@ class AdyenException extends Exception
         $this->errorType = $errorType;
         $this->pspReference = $pspReference;
         $this->adyenErrorCode = $adyenErrorCode;
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int)$code, $previous);
     }
 
     /**

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -309,7 +309,7 @@ class CurlClient implements ClientInterface
             $logger->error($decodeResult['errorCode'] . ': ' . $decodeResult['message']);
             throw new AdyenException(
                 $decodeResult['message'],
-                $decodeResult['status'],
+                $decodeResult['errorCode'],
                 null,
                 $decodeResult['status'],
                 $decodeResult['errorType'],


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Revert breaking change in 8.1.0
Keep `errorCode()` the same for backwards compatibility
**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**: Resolves #250  <!-- #-prefixed issue number -->
