### PR TITLE
Fixed example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ $service = new \Adyen\Service\Checkout($client);
 
 $json = '{
       "card": {
-        "encryptedCardNumber" => "test_4111111111111111",
-        "encryptedExpiryMonth" => "test_03",
-        "encryptedExpiryYear" => "test_2030",
-        "encryptedSecurityCode" => "test_737"
+        "encryptedCardNumber": "test_4111111111111111",
+        "encryptedExpiryMonth": "test_03",
+        "encryptedExpiryYear": "test_2030",
+        "encryptedSecurityCode": "test_737",
         "holderName": "John Smith"
       },
       "amount": {


### PR DESCRIPTION
**Description**
`json_decode($json, true)` cannot parse invalid json string and this line throws exception (because `$params` is NULL):
`$result = $service->payments($params);`

Fixed the json string

**Tested scenarios**
Ran the example code. It now works as expected.

**Fixed issue**: 
N/A
