### PR TITLE
V68 implementation: refunds + reversals

### DIFF
--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -76,6 +76,8 @@ abstract class AbstractResource
 
         $params = $this->addDefaultParametersToRequest($params);
 
+        $this->replacePathParameters($params);
+
         if ($this->allowApplicationInfo) {
             $params = $this->handleApplicationInfoInRequest($params);
         } elseif ($this->allowApplicationInfoPOS) {
@@ -98,7 +100,7 @@ abstract class AbstractResource
      */
     public function requestPost($params)
     {
-        // check if paramenters has a value
+        // check if parameters has a value
         if (!$params) {
             $msg = 'The parameters in the request are empty';
             $this->service->getClient()->getLogger()->error($msg);
@@ -215,5 +217,20 @@ abstract class AbstractResource
         } else {
             return false;
         }
+    }
+
+    /**
+     * @param $data
+     * @return void
+     */
+    private function replacePathParameters($data)
+    {
+        $this->endpoint = preg_replace_callback(
+            '/{([a-zA-Z]+)}/',
+            function ($matches) use ($data) {
+                return $data[$matches[1]] ?? $matches[0];
+            },
+            $this->endpoint
+        );
     }
 }

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -223,7 +223,7 @@ abstract class AbstractResource
         );
     }
       
-    /*  
+    /**
      * @param $params
      * @return mixed
      * @throws AdyenException

--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -60,6 +60,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $sessions;
 
     /**
+     * @var ResourceModel\Checkout\Refunds
+     */
+    protected $refunds;
+
+    /**
+     * @var ResourceModel\Checkout\Reversals
+     */
+    protected $reversals;
+
+    /**
      * Checkout constructor.
      *
      * @param \Adyen\Client $client
@@ -79,6 +89,8 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->paymentMethodsBalance = new \Adyen\Service\ResourceModel\Checkout\PaymentMethodsBalance($this);
         $this->donations = new \Adyen\Service\ResourceModel\Checkout\Donations($this);
         $this->sessions = new \Adyen\Service\ResourceModel\Checkout\Sessions($this);
+        $this->refunds = new \Adyen\Service\ResourceModel\Checkout\Refunds($this);
+        $this->reversals = new \Adyen\Service\ResourceModel\Checkout\Reversals($this);
     }
 
     /**
@@ -202,5 +214,27 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function sessions($params, $requestOptions = null)
     {
         return $this->sessions->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function refunds($params, $requestOptions = null)
+    {
+        return $this->refunds->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function reversals($params, $requestOptions = null)
+    {
+        return $this->reversals->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Checkout/Refunds.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Refunds.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class Refunds extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Payments constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/payments/{paymentPspReference}/refunds';
+        parent::__construct($service, $this->endpoint, $this->allowApplicationInfo);
+    }
+}

--- a/src/Adyen/Service/ResourceModel/Checkout/Reversals.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Reversals.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class Reversals extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Payments constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/payments/{paymentPspReference}/reversals';
+        parent::__construct($service, $this->endpoint, $this->allowApplicationInfo);
+    }
+}

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -129,6 +129,7 @@ class CheckoutTest extends TestCase
         $result = $service->payments($params);
 
         $this->assertEquals('Authorised', $result['resultCode']);
+        $this->pspReference = $result['pspReference'];
     }
 
     public function testPaymentsSuccessWithIdempotencyKey()
@@ -313,5 +314,48 @@ class CheckoutTest extends TestCase
         // Payment params are the same as response data
         $keyIntersect = array_intersect_key($params, $result);
         $this->assertEquals($params, $keyIntersect);
+    }
+
+    public function testRefunds()
+    {
+        $this->testPaymentsSuccess();
+
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            "paymentPspReference" => $this->pspReference,
+            "amount" => [
+                "currency" => "USD",
+                "value" => 100
+            ]
+        );
+
+        $result = $service->refunds($params);
+
+        $this->assertEquals('received', $result['status']);
+    }
+
+    public function testReversals()
+    {
+        $this->testPaymentsSuccess();
+
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            "paymentPspReference" => $this->pspReference,
+            "merchantAccount" => $this->merchantAccount,
+        );
+
+        $result = $service->reversals($params);
+
+        $this->assertEquals('received', $result['status']);
     }
 }


### PR DESCRIPTION
**Description**
Added path parameters handler that allows implementing the rest methods of the Checkout API integration.

Added `v68` Checkout methods implementation:
- POST [/payments/{paymentPspReference}/refunds](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/{paymentPspReference}/refunds)
- POST [/payments/{paymentPspReference}/reversals](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/{paymentPspReference}/reversals)

**Tested scenarios**
Both methods have integration test:
- \Adyen\Tests\Integration\CheckoutTest::testRefunds
- \Adyen\Tests\Integration\CheckoutTest::testReversals

