### PR TITLE
[PW-6283] Add manual capture payment methods list

### DIFF
--- a/src/Adyen/Util/ManualCapture.php
+++ b/src/Adyen/Util/ManualCapture.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen API Library for PHP
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+namespace Adyen\Util;
+
+class ManualCapture
+{
+    private $openInvoice;
+
+    /**
+     * ManualCapture constructor.
+     */
+    public function __construct()
+    {
+        $this->openInvoice = new OpenInvoice();
+    }
+
+    public function isManualCaptureSupported($notificationPaymentMethod): bool
+    {
+        $manualCaptureAllowed = false;
+        // For all openinvoice methods manual capture is the default
+        if ($this->openInvoice->isOpenInvoicePaymentMethod($notificationPaymentMethod)) {
+            return true;
+        }
+
+        switch ($notificationPaymentMethod) {
+            case 'cup':
+            case 'cartebancaire':
+            case 'visa':
+            case 'visadankort':
+            case 'mc':
+            case 'uatp':
+            case 'amex':
+            case 'maestro':
+            case 'maestrouk':
+            case 'diners':
+            case 'discover':
+            case 'jcb':
+            case 'laser':
+            case 'paypal':
+            case 'sepadirectdebit':
+            case 'dankort':
+            case 'elo':
+            case 'hipercard':
+            case 'mc_applepay':
+            case 'visa_applepay':
+            case 'amex_applepay':
+            case 'discover_applepay':
+            case 'maestro_applepay':
+            case 'paywithgoogle':
+            case 'svs':
+            case 'givex':
+            case 'valuelink':
+            case 'twint':
+            case 'carnet':
+            case 'pix':
+            case 'klarna':
+            case 'oney':
+            case 'affirm':
+            case 'bright':
+            case 'amazonpay':
+            case 'applepay':
+            case 'googlepay':
+            case 'mobilepay':
+            case 'vipps':
+                $manualCaptureAllowed = true;
+                break;
+            default:
+                break;
+        }
+
+        $paymentMethodsWithVariants = array(
+            'boleto',
+            'clearpay',
+            'afterpay',
+            'ratepay',
+            'zip',
+        );
+
+        //check the payment methods with variants
+        foreach ($paymentMethodsWithVariants as $paymentMethod) {
+            if (str_contains($notificationPaymentMethod, $paymentMethod)) {
+                $manualCaptureAllowed = true;
+            }
+        }
+        return $manualCaptureAllowed;
+    }
+}

--- a/src/Adyen/Util/ManualCapture.php
+++ b/src/Adyen/Util/ManualCapture.php
@@ -35,73 +35,66 @@ class ManualCapture
         $this->openInvoice = new OpenInvoice();
     }
 
+    private static $paymentMethods = array(
+        'cup',
+        'cartebancaire',
+        'visa',
+        'visadankort',
+        'mc',
+        'uatp',
+        'amex',
+        'maestro',
+        'maestrouk',
+        'diners',
+        'discover',
+        'jcb',
+        'laser',
+        'paypal',
+        'sepadirectdebit',
+        'dankort',
+        'elo',
+        'hipercard',
+        'mc_applepay',
+        'visa_applepay',
+        'amex_applepay',
+        'discover_applepay',
+        'maestro_applepay',
+        'paywithgoogle',
+        'svs',
+        'givex',
+        'valuelink',
+        'twint',
+        'carnet',
+        'pix',
+        'klarna',
+        'oney',
+        'affirm',
+        'bright',
+        'amazonpay',
+        'applepay',
+        'googlepay',
+        'mobilepay',
+        'vipps'
+    );
+
     public function isManualCaptureSupported($notificationPaymentMethod): bool
     {
         $manualCaptureAllowed = false;
-        // For all openinvoice methods manual capture is the default
+        //For all openinvoice methods manual capture is the default
         if ($this->openInvoice->isOpenInvoicePaymentMethod($notificationPaymentMethod)) {
             return true;
         }
 
-        switch ($notificationPaymentMethod) {
-            case 'cup':
-            case 'cartebancaire':
-            case 'visa':
-            case 'visadankort':
-            case 'mc':
-            case 'uatp':
-            case 'amex':
-            case 'maestro':
-            case 'maestrouk':
-            case 'diners':
-            case 'discover':
-            case 'jcb':
-            case 'laser':
-            case 'paypal':
-            case 'sepadirectdebit':
-            case 'dankort':
-            case 'elo':
-            case 'hipercard':
-            case 'mc_applepay':
-            case 'visa_applepay':
-            case 'amex_applepay':
-            case 'discover_applepay':
-            case 'maestro_applepay':
-            case 'paywithgoogle':
-            case 'svs':
-            case 'givex':
-            case 'valuelink':
-            case 'twint':
-            case 'carnet':
-            case 'pix':
-            case 'klarna':
-            case 'oney':
-            case 'affirm':
-            case 'bright':
-            case 'amazonpay':
-            case 'applepay':
-            case 'googlepay':
-            case 'mobilepay':
-            case 'vipps':
-                $manualCaptureAllowed = true;
-                break;
-            default:
-                break;
+        //Check for payment methods with no variants
+        if (in_array($notificationPaymentMethod, self::$paymentMethods)) {
+            return true;
         }
+        //Regex pattern for payment methods with variants
+        $paymentMethodsWithVariants = '/^afterpay|^boleto|^clearpay|^ratepay|^zip/';
 
-        $paymentMethodsWithVariants = array(
-            'boleto',
-            'clearpay',
-            'afterpay',
-            'ratepay',
-            'zip',
-        );
-
-        //check the payment methods with variants
-        foreach ($paymentMethodsWithVariants as $paymentMethod) {
-            if (str_contains($notificationPaymentMethod, $paymentMethod)) {
-                $manualCaptureAllowed = true;
-            }
+        //Check the payment methods with variants
+        if (preg_match($paymentMethodsWithVariants, $notificationPaymentMethod)) {
+            $manualCaptureAllowed = true;
         }
         return $manualCaptureAllowed;
     }

--- a/tests/Unit/Util/ManualCaptureTest.php
+++ b/tests/Unit/Util/ManualCaptureTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen API Library for PHP
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+namespace Adyen\Tests\Unit\Util;
+
+
+use Adyen\Util\ManualCapture;
+use PHPUnit\Framework\TestCase;
+
+class ManualCaptureTest extends TestCase
+{
+    public function paymentMethodsDataProvider()
+    {
+        return [
+            ['boleto', true],
+            ['boletobancario_bancodobrazil', true],
+            ['boletobancario_santander', true],
+            ['boletobancario_hsbc', true],
+            ['clearpay', true],
+            ['clearpay', true],
+            ['clearpay_ES', true],
+            ['clearpay_FR', true],
+            ['clearpay_GB', true],
+            ['clearpay_IT', true],
+            ['afterpay', true],
+            ['afterpay_b2b', true],
+            ['afterpay_DE', true],
+            ['afterpay_NL', true],
+            ['afterpaytouch', true],
+            ['afterpaytouch_US', true],
+            ['ratepay', true],
+            ['ratepay_AT', true],
+            ['ratepay_CH', true],
+            ['ratepay_directdebit', true],
+            ['ratepay_directdebit_AT', true],
+            ['ratepay_directdebit_NL', true],
+            ['zip', true],
+            ['zip_AU', true],
+            ['zip_CA', true]
+        ];
+    }
+
+    /**
+     * @dataProvider paymentMethodsDataProvider
+     */
+    public function testIsManualCaptureSupported($paymentMethod, $expectedResult)
+    {
+        $manualCapture = new ManualCapture();
+        $actualResult = $manualCapture->isManualCaptureSupported($paymentMethod);
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+}

--- a/tests/Unit/Util/ManualCaptureTest.php
+++ b/tests/Unit/Util/ManualCaptureTest.php
@@ -23,7 +23,6 @@
 
 namespace Adyen\Tests\Unit\Util;
 
-
 use Adyen\Util\ManualCapture;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Util/ManualCaptureTest.php
+++ b/tests/Unit/Util/ManualCaptureTest.php
@@ -50,12 +50,25 @@ class ManualCaptureTest extends TestCase
             ['ratepay', true],
             ['ratepay_AT', true],
             ['ratepay_CH', true],
+            ['paypal', true],
+            ['amazonpay', true],
             ['ratepay_directdebit', true],
             ['ratepay_directdebit_AT', true],
             ['ratepay_directdebit_NL', true],
             ['zip', true],
             ['zip_AU', true],
-            ['zip_CA', true]
+            ['zip_CA', true],
+            ['abrapetite', false],
+            ['abrapetite_credit', false],
+            ['abrapetite_prepaid', false],
+            ['authreferral_card', false],
+            ['authreferral_mc', false],
+            ['bankTransfer', false],
+            ['bankTransfer_CA', false],
+            ['bankTransfer_CY', false],
+            ['bankTransfer_US', false],
+            ['doku', false],
+            ['doku_card', false]
         ];
     }
 


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The payment methods that supports AUTH flow are also supporting manual capture. The list with the payment methods is added in the library so we have one method to update and to not duplicate the list across the platforms, 

**Tested scenarios**
Added a unit test for the payment methods variants
