### PR TITLE
Add support for custom certificate in the Curl Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The library supports all APIs under the following services:
   * [Hosted Onboarding API](https://docs.adyen.com/api-explorer/#/Hop/v6/overview) Current supported version: **v6**
 * [Cloud-based Terminal API](https://docs.adyen.com/point-of-sale/terminal-api-reference): Our point-of-sale integration.
 * [Referrals API](https://docs.adyen.com/risk-management/automate-submitting-referrals/referrals-api-reference): Endpoints to [automate submitting referrals](https://docs.adyen.com/risk-management/automate-submitting-referrals) for Adyen risk rules.
+* [Refunds API](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/{paymentPspReference}/refunds): Refunds a payment that has been captured, and returns a unique reference for this request. Current supported version: **v68**
+* [Reversals API](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/{paymentPspReference}/reversals): Refunds a payment if it has already been captured, and cancels a payment if it has not yet been captured. Current supported version: **v68**
 
 For more information, refer to our [documentation](https://docs.adyen.com/) or the [API Explorer](https://docs.adyen.com/api-explorer/).
 

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -137,6 +137,16 @@ class Client
     }
 
     /**
+     * Set the path to a CA bundle file that enables verification using a custom certificate
+     *
+     * @param string $certFilePath
+     */
+    public function setSslVerify($certFilePath)
+    {
+        $this->config->set('ssl-verify', $certFilePath);
+    }
+
+    /**
      * Set environment to connect to test or live platform of Adyen
      * For live please specify the unique identifier.
      *

--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -103,6 +103,16 @@ class Config implements ConfigInterface
     }
 
     /**
+     * Get the path to a CA bundle file that enables verification using a custom certificate
+     *
+     * @return mixed|null
+     */
+    public function getSslVerify()
+    {
+        return !empty($this->data['ssl-verify']) ? $this->data['ssl-verify'] : null;
+    }
+
+    /**
      * @return mixed|string
      */
     public function getInputType()

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -85,6 +85,28 @@ class CurlClient implements ClientInterface
     }
 
     /**
+     * Set the path to a custom CA bundle in the current curl configuration.
+     *
+     * @param resource $ch
+     * @param string $certFilePath
+     * @throws AdyenException
+     */
+    public function curlSetSslVerify($ch, $certFilePath)
+    {
+        if (empty($certFilePath)) {
+            return;
+        }
+
+        if (!file_exists($certFilePath)) {
+            throw new AdyenException("SSL CA bundle not found: {$certFilePath}");
+        }
+
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_CAINFO, $certFilePath);
+    }
+
+    /**
      * Request to Adyen with query string used for Directory Lookup
      *
      * @param \Adyen\Service $service
@@ -102,6 +124,7 @@ class CurlClient implements ClientInterface
         $password = $config->getPassword();
         $httpProxy = $config->getHttpProxy();
         $environment = $config->getEnvironment();
+        $sslVerify = $config->getSslVerify();
 
         // log the request
         $this->logRequest($logger, $requestUrl, $environment, $params);
@@ -113,6 +136,7 @@ class CurlClient implements ClientInterface
         curl_setopt($ch, CURLOPT_POST, 1);
 
         $this->curlSetHttpProxy($ch, $httpProxy);
+        $this->curlSetSslVerify($ch, $sslVerify);
 
         // set authorisation
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
@@ -356,6 +380,7 @@ class CurlClient implements ClientInterface
         $xApiKey = $config->getXApiKey();
         $httpProxy = $config->getHttpProxy();
         $environment = $config->getEnvironment();
+        $sslVerify = $config->getSslVerify();
 
         $jsonRequest = json_encode($params);
 
@@ -382,6 +407,7 @@ class CurlClient implements ClientInterface
         }
 
         $this->curlSetHttpProxy($ch, $httpProxy);
+        $this->curlSetSslVerify($ch, $sslVerify);
 
         //create a custom User-Agent
         $userAgent = $config->get('applicationName') . " " .

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -74,8 +74,8 @@ class CurlClient implements ClientInterface
         }
 
         $proxy = "";
-        if (isset($urlParts["schema"])) {
-            $proxy = $urlParts["schema"] . "://";
+        if (isset($urlParts["scheme"])) {
+            $proxy = $urlParts["scheme"] . "://";
         }
         $proxy .= $urlParts["host"];
         if (isset($urlParts["port"])) {

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -73,7 +73,11 @@ class CurlClient implements ClientInterface
             throw new AdyenException("Invalid proxy configuration " . $httpProxy);
         }
 
-        $proxy = $urlParts["host"];
+        $proxy = "";
+        if (isset($urlParts["schema"])) {
+            $proxy = $urlParts["schema"] . "://";
+        }
+        $proxy .= $urlParts["host"];
         if (isset($urlParts["port"])) {
             $proxy .= ":" . $urlParts["port"];
         }


### PR DESCRIPTION
**Description**
Added support for setting a custom certificate path in the Curl Client.

This is needed in our scenario when proxying Adyen requests through [VGS](https://www.verygoodsecurity.com/docs/guides/outbound-connection#tls-certificates) for PCI compliance.

In addition in this MR, if a proxy URL contains the scheme, the proposed change will keep it in the final URL that gets set into `CURLOPT_PROXY`. By stripping it, some proxies (VGS included) are not connecting properly.