### PR TITLE
[PW-6598] Add query parameters to get merchant call

### DIFF
--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -361,7 +361,10 @@ class CurlClient implements ClientInterface
 
         // log the request
         $this->logRequest($logger, $requestUrl, $environment, $params);
-
+        //Check if there are url query params to construct the url
+        if ($method === self::HTTP_METHOD_GET && !empty($params)) {
+            $requestUrl .= '?' . http_build_query($params);
+        }
         //Initiate cURL.
         $ch = curl_init($requestUrl);
 

--- a/src/Adyen/Service/ResourceModel/Management/AllowedOrigins.php
+++ b/src/Adyen/Service/ResourceModel/Management/AllowedOrigins.php
@@ -17,13 +17,14 @@ class AllowedOrigins extends \Adyen\Service\AbstractResource
     protected $allowApplicationInfo = false;
 
     /**
+     * @param array $queryParams
      * @return mixed
      * @throws \Adyen\AdyenException
      */
-    public function list()
+    public function list(array $queryParams = [])
     {
         $url = $this->managementEndpoint . self::ALLOWED_ORIGINS;
-        return $this->requestHttp($url, 'get');
+        return $this->requestHttp($url, 'get', $queryParams);
     }
 
     /**

--- a/src/Adyen/Service/ResourceModel/Management/CompanyAccount.php
+++ b/src/Adyen/Service/ResourceModel/Management/CompanyAccount.php
@@ -13,13 +13,14 @@ class CompanyAccount extends \Adyen\Service\AbstractResource
     protected $allowApplicationInfo = false;
 
     /**
+     * @param array $queryParams
      * @return mixed
      * @throws \Adyen\AdyenException
      */
-    public function list()
+    public function list(array $queryParams = [])
     {
         $url = $this->managementEndpoint . "/companies";
-        return $this->requestHttp($url, 'get');
+        return $this->requestHttp($url, 'get', $queryParams);
     }
 
     /**

--- a/src/Adyen/Service/ResourceModel/Management/MerchantAccount.php
+++ b/src/Adyen/Service/ResourceModel/Management/MerchantAccount.php
@@ -13,12 +13,16 @@ class MerchantAccount extends \Adyen\Service\AbstractResource
     protected $allowApplicationInfo = false;
 
     /**
+     * @param array|null $queryParams
      * @return mixed
      * @throws \Adyen\AdyenException
      */
-    public function list()
+    public function list(array $queryParams = null)
     {
         $url = $this->managementEndpoint . "/merchants";
+        if (!empty($queryParams)) {
+            $url .= '?' . http_build_query($queryParams);
+        }
         return $this->requestHttp($url, 'get');
     }
 

--- a/src/Adyen/Service/ResourceModel/Management/MerchantAccount.php
+++ b/src/Adyen/Service/ResourceModel/Management/MerchantAccount.php
@@ -13,17 +13,14 @@ class MerchantAccount extends \Adyen\Service\AbstractResource
     protected $allowApplicationInfo = false;
 
     /**
-     * @param array|null $queryParams
+     * @param array $queryParams
      * @return mixed
      * @throws \Adyen\AdyenException
      */
-    public function list(array $queryParams = null)
+    public function list(array $queryParams = [])
     {
         $url = $this->managementEndpoint . "/merchants";
-        if (!empty($queryParams)) {
-            $url .= '?' . http_build_query($queryParams);
-        }
-        return $this->requestHttp($url, 'get');
+        return $this->requestHttp($url, 'get', $queryParams);
     }
 
     /**

--- a/tests/Integration/ManagementTest.php
+++ b/tests/Integration/ManagementTest.php
@@ -37,7 +37,7 @@ class ManagementTest extends TestCase
         $this->assertNotEmpty($response[self::LINKS]);
         $this->assertNotEmpty($response[self::DATA]);
         $this->assertNotEmpty($response[self::ITEMS_TOTAL]);
-        $this->assertTrue($response[self::DATA] > 0);
+        $this->assertTrue(count($response[self::DATA]) > 0);
     }
 
     /**

--- a/tests/Integration/ManagementTest.php
+++ b/tests/Integration/ManagementTest.php
@@ -51,7 +51,7 @@ class ManagementTest extends TestCase
         $this->assertNotEmpty($response[self::LINKS]);
         $this->assertNotEmpty($response[self::DATA]);
         $this->assertNotEmpty($response[self::ITEMS_TOTAL]);
-        $this->assertEquals(2, count($response[self::DATA]) );
+        $this->assertEquals(2, count($response[self::DATA]));
     }
 
     /**

--- a/tests/Integration/ManagementTest.php
+++ b/tests/Integration/ManagementTest.php
@@ -37,7 +37,21 @@ class ManagementTest extends TestCase
         $this->assertNotEmpty($response[self::LINKS]);
         $this->assertNotEmpty($response[self::DATA]);
         $this->assertNotEmpty($response[self::ITEMS_TOTAL]);
-        $this->assertTrue($this->count($response[self::DATA]) > 0);
+        $this->assertTrue($response[self::DATA] > 0);
+    }
+
+    /**
+     * Get /merchants with query parameters
+     * @throws \Adyen\AdyenException
+     */
+    public function testGetMerchantsWithQueryParameters()
+    {
+        $response = $this->management->merchantAccount->list(array("pageSize"=> 2));
+        $this->assertNotEmpty($response);
+        $this->assertNotEmpty($response[self::LINKS]);
+        $this->assertNotEmpty($response[self::DATA]);
+        $this->assertNotEmpty($response[self::ITEMS_TOTAL]);
+        $this->assertTrue(count($response[self::DATA]) == 2);
     }
 
     /**

--- a/tests/Integration/ManagementTest.php
+++ b/tests/Integration/ManagementTest.php
@@ -51,7 +51,7 @@ class ManagementTest extends TestCase
         $this->assertNotEmpty($response[self::LINKS]);
         $this->assertNotEmpty($response[self::DATA]);
         $this->assertNotEmpty($response[self::ITEMS_TOTAL]);
-        $this->assertTrue(count($response[self::DATA]) == 2);
+        $this->assertEquals(2, count($response[self::DATA]) );
     }
 
     /**


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add to /merchants endpoint call query params using an associative array
- Query parameters that could be used 
1. `pageNumber` 
The number of the page to fetch.
2. `pageSize` 
The number of items to have on a page, maximum 100. The default is 10 items on a page


**Tested scenarios**
End to end test added for pageSize
