### PR TITLE
[PW-6531]Add /test and /list endpoints for webhooks

### DIFF
--- a/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
+++ b/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
@@ -4,9 +4,13 @@
 namespace Adyen\Service\ResourceModel\Management;
 
 use Adyen\AdyenException;
+use Adyen\Service\AbstractResource;
 
-class MerchantWebhooks extends \Adyen\Service\AbstractResource
+class MerchantWebhooks extends AbstractResource
 {
+    const MERCHANTS = "/merchants/";
+    const WEBHOOKS = "/webhooks";
+
     /**
      * Include applicationInfo key in the request parameters
      *
@@ -21,7 +25,7 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
      */
     public function list($merchantId)
     {
-        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks";
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS;
         return $this->requestHttp($url, 'get');
     }
 
@@ -33,7 +37,7 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
      */
     public function create($merchantId, $params)
     {
-        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks";
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS;
         return $this->requestHttp($url, 'post', $params);
     }
 
@@ -46,7 +50,7 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
      */
     public function update($merchantId, $webhookId, $params)
     {
-        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks/" . $webhookId;
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS . "/" . $webhookId;
         return $this->requestHttp($url, 'patch', $params);
     }
 
@@ -58,7 +62,7 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
      */
     public function generateHmac($merchantId, $webhookId)
     {
-        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks/" . $webhookId . "/generateHmac";
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS . "/" . $webhookId . "/generateHmac";
         return $this->requestHttp($url, 'post');
     }
 
@@ -71,7 +75,7 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
      */
     public function test($merchantId, $webhookId, $params)
     {
-        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks/" . $webhookId . "/test";
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS . "/" . $webhookId . "/test";
         return $this->requestHttp($url, 'post', $params);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
+++ b/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
@@ -62,7 +62,8 @@ class MerchantWebhooks extends AbstractResource
      */
     public function generateHmac($merchantId, $webhookId)
     {
-        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS . "/" . $webhookId . "/generateHmac";
+        $url = $this->managementEndpoint . self::MERCHANTS . $merchantId . self::WEBHOOKS . "/"
+            . $webhookId . "/generateHmac";
         return $this->requestHttp($url, 'post');
     }
 

--- a/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
+++ b/src/Adyen/Service/ResourceModel/Management/MerchantWebhooks.php
@@ -16,6 +16,17 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
 
     /**
      * @param $merchantId
+     * @return mixed
+     * @throws AdyenException
+     */
+    public function list($merchantId)
+    {
+        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks";
+        return $this->requestHttp($url, 'get');
+    }
+
+    /**
+     * @param $merchantId
      * @param $params
      * @return mixed
      * @throws AdyenException
@@ -49,5 +60,18 @@ class MerchantWebhooks extends \Adyen\Service\AbstractResource
     {
         $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks/" . $webhookId . "/generateHmac";
         return $this->requestHttp($url, 'post');
+    }
+
+    /**
+     * @param $merchantId
+     * @param $webhookId
+     * @param $params
+     * @return mixed
+     * @throws AdyenException
+     */
+    public function test($merchantId, $webhookId, $params)
+    {
+        $url = $this->managementEndpoint . "/merchants/" . $merchantId . "/webhooks/" . $webhookId . "/test";
+        return $this->requestHttp($url, 'post', $params);
     }
 }

--- a/tests/Integration/ManagementTest.php
+++ b/tests/Integration/ManagementTest.php
@@ -209,6 +209,33 @@ class ManagementTest extends TestCase
         $this->assertNotEmpty($response['hmacKey']);
     }
 
+    /**
+     * post /merchants/{id}/webhooks/{webhookId}/test
+     *
+     * @throws \Adyen\AdyenException
+     */
+    public function testMerchantWebhooksTest()
+    {
+        if (empty($this->settings['merchantAccount']) ||
+            $this->settings['merchantAccount'] == self::YOUR_MERCHANT_ACCOUNT) {
+            $this->skipTest(self::SKIP_TEST_MESSAGE);
+            return null;
+        }
+        $listWebhooksResponse = $this->management->merchantWebhooks->list($this->settings['merchantAccount']);
+        $this->assertNotEmpty($listWebhooksResponse);
+
+        if (isset($listWebhooksResponse['data'][0]['id'])) {
+            $params = ['types' => ['AUTHORISATION']];
+            $testWebhook = $this->management->merchantWebhooks->test(
+                $this->settings['merchantAccount'],
+                $listWebhooksResponse['data'][0]['id'],
+                $params
+            );
+            $this->assertNotEmpty($testWebhook);
+        } else {
+            $this->fail("Unable to retrieve the webhooks");
+        }
+    }
 
     /**
      * Get /me/allowedOrigins


### PR DESCRIPTION
Add test and get list endpoints for webhook merchants account

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
To test properly the webhook configuration we need to add the `/test` endpoint and pass the `merhcantAccount` with the `webhookId`. For details please check the [docs](https://docs.adyen.com/api-explorer/#/ManagementService/v1/post/merchants/{id}/webhooks/{webhookId}/test) 

Endpoints added: 
- `https://management-test.adyen.com/v1/merchants/{id}/webhooks/{webhookId}/test`
- `https://docs.adyen.com/api-explorer/#/ManagementService/v1/get/merchants/{id}/webhooks`
- 
**Tested scenarios**
Get all the merchants endpoints
It is not possible to use the test endpoint by creating a unit test
