### PR TITLE
[PW-4648] Add deprecated annotation for directory lookup function

### DIFF
--- a/src/Adyen/Service/DirectoryLookup.php
+++ b/src/Adyen/Service/DirectoryLookup.php
@@ -2,6 +2,11 @@
 
 namespace Adyen\Service;
 
+/**
+ * Class DirectoryLookup
+ * @deprecated
+ * @package Adyen\Service
+ */
 class DirectoryLookup extends \Adyen\Service
 {
     /**
@@ -23,6 +28,7 @@ class DirectoryLookup extends \Adyen\Service
 
     /**
      * @param $params
+     * @deprecated
      * @return mixed
      * @throws \Adyen\AdyenException
      */


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
With Directory Lookup, you can fetch the available payment methods from Adyen. However it is reaching the end of life so it is marked as `deprecated` so we prevent new merchants to use it. 

**Tested scenarios**
<!-- Description of tested scenarios -->
It is only annotation so the tests should pass. No new tests added