### PR TITLE
Add Array type in config constructor function for old php versions

### DIFF
--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -32,9 +32,9 @@ class Config implements ConfigInterface
     /**
      * Config constructor.
      *
-     * @param null $params
+     * @param array|null $params
      */
-    public function __construct($params = null)
+    public function __construct(array $params = null)
     {
         if ($params && is_array($params)) {
             foreach ($params as $key => $param) {


### PR DESCRIPTION
**Description**
#381 mentioned correctly that our config constructor will not properly set null array for older than php8.