### PR TITLE
[PW-7020] - Update buildOpenInvoiceLineItem method according to Checkout API v69

### DIFF
--- a/src/Adyen/Service/Builder/OpenInvoice.php
+++ b/src/Adyen/Service/Builder/OpenInvoice.php
@@ -28,46 +28,43 @@ class OpenInvoice
     /**
      * Build invoice line items for open invoice payment methods
      *
-     * @param string $description
-     * @param float $itemAmount
-     * @param float $itemVatAmount
-     * @param float $itemVatPercentage
-     * @param int $numberOfItems
-     * @param string $vatCategory
      * @param string $itemId
-     * @param string|null $productUrl
+     * @param string $description
+     * @param string $itemCategory
+     * @param int $amountExcludingTax
+     * @param int $amountIncludingTax
+     * @param int $taxAmount
+     * @param int $taxPercentage
+     * @param int $quantity
+     * @param string $productUrl
      * @param string|null $imageUrl
      * @return array
      */
     public function buildOpenInvoiceLineItem(
-        $description,
-        $itemAmount,
-        $itemVatAmount,
-        $itemVatPercentage,
-        $numberOfItems,
-        $vatCategory,
-        $itemId,
-        $productUrl = null,
-        $imageUrl = null
-    ) {
+        string $itemId,
+        string $description,
+        string $itemCategory,
+        int $amountExcludingTax,
+        int $amountIncludingTax,
+        int $taxAmount,
+        int $taxPercentage,
+        int $quantity,
+        string $productUrl,
+        string $imageUrl = null
+    ): array {
         $lineItem = array();
-        // item id is optional
-        if (!empty($itemId)) {
-            $lineItem['id'] = $itemId;
-        }
 
+        $lineItem['id'] = $itemId;
         $lineItem['description'] = $description;
-        $lineItem['amountExcludingTax'] = $itemAmount;
-        $lineItem['taxAmount'] = $itemVatAmount;
-        $lineItem['taxPercentage'] = $itemVatPercentage;
-        $lineItem['quantity'] = $numberOfItems;
-        $lineItem['taxCategory'] = $vatCategory;
+        $lineItem['itemCategory'] = $itemCategory;
+        $lineItem['amountExcludingTax'] = $amountExcludingTax;
+        $lineItem['amountIncludingTax'] = $amountIncludingTax;
+        $lineItem['taxAmount'] = $taxAmount;
+        $lineItem['taxPercentage'] = $taxPercentage;
+        $lineItem['quantity'] = $quantity;
+        $lineItem['productUrl'] = $productUrl;
 
-        if (!is_null($productUrl)) {
-            $lineItem['productUrl'] = $productUrl;
-        }
-
-        if (!is_null($imageUrl)) {
+        if (isset($imageUrl)) {
             $lineItem['imageUrl'] = $imageUrl;
         }
 

--- a/tests/Integration/Builder/OpenInvoiceTest.php
+++ b/tests/Integration/Builder/OpenInvoiceTest.php
@@ -31,17 +31,32 @@ class OpenInvoiceTest extends TestCase
     public function testBuildOpenInvoiceLineItem()
     {
         $expectedResult = array(
-            'id' => "1",
-            'description' => "item-description",
+            'id' => '1',
+            'description' => 'item-description',
+            'itemCategory' => 'product-category',
             'amountExcludingTax' => 1000,
-            'taxAmount' => 21,
-            'taxPercentage' => 10,
+            'amountIncludingTax' => 1210,
+            'taxAmount' => 210,
+            'taxPercentage' => 21,
             'quantity' => 10,
-            'taxCategory' => "vat"
-
+            'productUrl' => 'http://localhost/producturl.html',
+            'imageUrl' => 'http://localhost/imageurl.jpg'
         );
+
         $openInvoice = new OpenInvoice();
-        $result = $openInvoice->buildOpenInvoiceLineItem("item-description", 1000, 21, 10, 10, "vat", "1");
+        $result = $openInvoice->buildOpenInvoiceLineItem(
+            '1',
+            'item-description',
+            'product-category',
+            1000,
+            1210,
+            210,
+            21,
+            10,
+            'http://localhost/producturl.html',
+            'http://localhost/imageurl.jpg'
+        );
+
         $this->assertEquals($result, $expectedResult);
     }
 }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Update buildOpenInvoiceLineItem method according to [Checkout API v69](https://docs.adyen.com/api-explorer/#/CheckoutService/v69/post/payments).

- `amountIncludingTax` and `itemCategory` parameters added.
- `taxCategory` parameter removed.