### PR TITLE
[PW-7170] - Add region based endpoints for terminal api

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -502,6 +502,10 @@ class Client
      */
     public function setRegion(string $region): void
     {
+        if (!array_key_exists($region, Region::TERMINAL_API_ENDPOINTS_MAPPING)) {
+            throw new AdyenException('Trying to set invalid region!');
+        }
+
         $this->config->set('region', $region);
     }
 }

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -31,6 +31,8 @@ class Client
     const API_HOP_VERSION = "v6";
     const ENDPOINT_TERMINAL_CLOUD_TEST = "https://terminal-api-test.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
+    const ENDPOINT_TERMINAL_CLOUD_US_LIVE = "https://terminal-api-live-us.adyen.com";
+    const ENDPOINT_TERMINAL_CLOUD_AU_LIVE = "https://terminal-api-live-au.adyen.com";
     const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com/checkout";
     const ENDPOINT_CHECKOUT_LIVE_SUFFIX = "-checkout-live.adyenpayments.com/checkout";
     const ENDPOINT_PROTOCOL = "https://";
@@ -492,5 +494,14 @@ class Client
         $logger->pushHandler(new StreamHandler('php://stderr', Logger::NOTICE));
 
         return $logger;
+    }
+
+    /**
+     * @param string $region
+     * @return void
+     */
+    public function setRegion(string $region): void
+    {
+        $this->config->set('region', $region);
     }
 }

--- a/src/Adyen/Region.php
+++ b/src/Adyen/Region.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Adyen;
+
+class Region
+{
+    const EU = "eu";
+    const US = "us";
+    const AU = "au";
+}

--- a/src/Adyen/Region.php
+++ b/src/Adyen/Region.php
@@ -7,4 +7,10 @@ class Region
     const EU = "eu";
     const US = "us";
     const AU = "au";
+
+    const TERMINAL_API_ENDPOINTS_MAPPING = [
+        self::EU => Client::ENDPOINT_TERMINAL_CLOUD_LIVE,
+        self::US => Client::ENDPOINT_TERMINAL_CLOUD_US_LIVE,
+        self::AU => Client::ENDPOINT_TERMINAL_CLOUD_AU_LIVE,
+    ];
 }

--- a/src/Adyen/Service/PosPayment.php
+++ b/src/Adyen/Service/PosPayment.php
@@ -36,9 +36,9 @@ class PosPayment extends \Adyen\ApiKeyAuthenticatedService
     public function __construct(\Adyen\Client $client)
     {
         parent::__construct($client);
-        $region = $this->getClient()->getConfig('region');
+        $region = $this->getClient()->getConfig()->get('region');
 
-        if (isset($region) && $this->getClient()->getConfig('environment') == \Adyen\Environment::LIVE) {
+        if (isset($region) && $this->getClient()->getConfig()->get('environment') == \Adyen\Environment::LIVE) {
             switch ($region) {
                 case Region::US:
                     $this->getClient()->getConfig()->set(

--- a/src/Adyen/Service/PosPayment.php
+++ b/src/Adyen/Service/PosPayment.php
@@ -3,6 +3,7 @@
 namespace Adyen\Service;
 
 use Adyen\Client;
+use Adyen\Environment;
 use Adyen\Region;
 
 class PosPayment extends \Adyen\ApiKeyAuthenticatedService
@@ -33,34 +34,18 @@ class PosPayment extends \Adyen\ApiKeyAuthenticatedService
      * @param \Adyen\Client $client
      * @throws \Adyen\AdyenException
      */
-    public function __construct(\Adyen\Client $client)
+    public function __construct(Client $client)
     {
         parent::__construct($client);
 
         $region = $this->getClient()->getConfig()->get('region');
         $environment = $this->getClient()->getConfig()->get('environment');
 
-        if (isset($region) && $environment == \Adyen\Environment::LIVE) {
-            switch ($region) {
-                case Region::US:
-                    $this->getClient()->getConfig()->set(
-                        'endpointTerminalCloud',
-                        Client::ENDPOINT_TERMINAL_CLOUD_US_LIVE
-                    );
-                    break;
-                case Region::AU:
-                    $this->getClient()->getConfig()->set(
-                        'endpointTerminalCloud',
-                        Client::ENDPOINT_TERMINAL_CLOUD_AU_LIVE
-                    );
-                    break;
-                case Region::EU:
-                default:
-                    $this->getClient()->getConfig()->set(
-                        'endpointTerminalCloud',
-                        Client::ENDPOINT_TERMINAL_CLOUD_LIVE
-                    );
-            }
+        if (isset($region) && $environment == Environment::LIVE) {
+            $this->getClient()->getConfig()->set(
+                'endpointTerminalCloud',
+                Region::TERMINAL_API_ENDPOINTS_MAPPING[$region]
+            );
         }
 
         $this->runTenderSync = new \Adyen\Service\ResourceModel\Payment\TerminalCloudAPI($this, false);

--- a/src/Adyen/Service/PosPayment.php
+++ b/src/Adyen/Service/PosPayment.php
@@ -2,6 +2,9 @@
 
 namespace Adyen\Service;
 
+use Adyen\Client;
+use Adyen\Region;
+
 class PosPayment extends \Adyen\ApiKeyAuthenticatedService
 {
     /**
@@ -33,6 +36,31 @@ class PosPayment extends \Adyen\ApiKeyAuthenticatedService
     public function __construct(\Adyen\Client $client)
     {
         parent::__construct($client);
+        $region = $this->getClient()->getConfig('region');
+
+        if (isset($region) && $this->getClient()->getConfig('environment') == \Adyen\Environment::LIVE) {
+            switch ($region) {
+                case Region::US:
+                    $this->getClient()->getConfig()->set(
+                        'endpointTerminalCloud',
+                        Client::ENDPOINT_TERMINAL_CLOUD_US_LIVE
+                    );
+                    break;
+                case Region::AU:
+                    $this->getClient()->getConfig()->set(
+                        'endpointTerminalCloud',
+                        Client::ENDPOINT_TERMINAL_CLOUD_AU_LIVE
+                    );
+                    break;
+                case Region::EU:
+                default:
+                    $this->getClient()->getConfig()->set(
+                        'endpointTerminalCloud',
+                        Client::ENDPOINT_TERMINAL_CLOUD_LIVE
+                    );
+            }
+        }
+
         $this->runTenderSync = new \Adyen\Service\ResourceModel\Payment\TerminalCloudAPI($this, false);
         $this->runTenderAsync = new \Adyen\Service\ResourceModel\Payment\TerminalCloudAPI($this, true);
         $this->connectedTerminals = new \Adyen\Service\ResourceModel\Payment\ConnectedTerminals($this);

--- a/src/Adyen/Service/PosPayment.php
+++ b/src/Adyen/Service/PosPayment.php
@@ -36,9 +36,11 @@ class PosPayment extends \Adyen\ApiKeyAuthenticatedService
     public function __construct(\Adyen\Client $client)
     {
         parent::__construct($client);
-        $region = $this->getClient()->getConfig()->get('region');
 
-        if (isset($region) && $this->getClient()->getConfig()->get('environment') == \Adyen\Environment::LIVE) {
+        $region = $this->getClient()->getConfig()->get('region');
+        $environment = $this->getClient()->getConfig()->get('environment');
+
+        if (isset($region) && $environment == \Adyen\Environment::LIVE) {
             switch ($region) {
                 case Region::US:
                     $this->getClient()->getConfig()->set(

--- a/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
+++ b/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
@@ -2,6 +2,9 @@
 
 namespace Adyen\Service\ResourceModel\Payment;
 
+use Adyen\Client;
+use Adyen\Region;
+
 class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 {
     /**
@@ -31,11 +34,30 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
      */
     public function __construct($service, $asynchronous)
     {
-        if ($asynchronous) {
-            $this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/async';
+        $region = $service->getClient()->getConfig('region');
+
+        if (isset($region) && $service->getClient()->getConfig('environment') == \Adyen\Environment::LIVE) {
+            switch ($region) {
+                case Region::US:
+                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_US_LIVE;
+                    break;
+                case Region::AU:
+                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_AU_LIVE;
+                    break;
+                case Region::EU:
+                default:
+                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_LIVE;
+            }
         } else {
-            $this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/sync';
+            $endpointUrl = $service->getClient()->getConfig()->get('endpointTerminalCloud');
         }
+
+        if ($asynchronous) {
+            $this->endpoint = $endpointUrl . '/async';
+        } else {
+            $this->endpoint = $endpointUrl . '/sync';
+        }
+
         parent::__construct($service, $this->endpoint, $this->allowApplicationInfo, $this->allowApplicationInfoPOS);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
+++ b/src/Adyen/Service/ResourceModel/Payment/TerminalCloudAPI.php
@@ -2,9 +2,6 @@
 
 namespace Adyen\Service\ResourceModel\Payment;
 
-use Adyen\Client;
-use Adyen\Region;
-
 class TerminalCloudAPI extends \Adyen\Service\AbstractResource
 {
     /**
@@ -34,30 +31,11 @@ class TerminalCloudAPI extends \Adyen\Service\AbstractResource
      */
     public function __construct($service, $asynchronous)
     {
-        $region = $service->getClient()->getConfig('region');
-
-        if (isset($region) && $service->getClient()->getConfig('environment') == \Adyen\Environment::LIVE) {
-            switch ($region) {
-                case Region::US:
-                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_US_LIVE;
-                    break;
-                case Region::AU:
-                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_AU_LIVE;
-                    break;
-                case Region::EU:
-                default:
-                    $endpointUrl = Client::ENDPOINT_TERMINAL_CLOUD_LIVE;
-            }
-        } else {
-            $endpointUrl = $service->getClient()->getConfig()->get('endpointTerminalCloud');
-        }
-
         if ($asynchronous) {
-            $this->endpoint = $endpointUrl . '/async';
+            $this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/async';
         } else {
-            $this->endpoint = $endpointUrl . '/sync';
+            $this->endpoint = $service->getClient()->getConfig()->get('endpointTerminalCloud') . '/sync';
         }
-
         parent::__construct($service, $this->endpoint, $this->allowApplicationInfo, $this->allowApplicationInfoPOS);
     }
 }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`setRegion()` method is defined in the `Client` class to set the region of the call.

This method expects `us`,`au` or `eu` as an input. Then, in the `PosPayment` class constructor, terminal api endpoint is overridden with the help this parameter if it is set.