### PR TITLE
[PW-7157]Set region use in_array

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -502,7 +502,7 @@ class Client
      */
     public function setRegion(string $region): void
     {
-        if (!array_key_exists($region, Region::TERMINAL_API_ENDPOINTS_MAPPING)) {
+        if (!in_array($region, Region::TERMINAL_API_ENDPOINTS_MAPPING)) {
             throw new AdyenException('Trying to set invalid region!');
         }
 


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Set region was using array_key_exists which returns wrong boolean for this array. The reason is that `in_array` checks if a value exists in an array checks the values and not the keys. On the other hand the 
`array_key_exists` checks if the given key or index exists in the array checks in keys, not in values and returns true or false 
**Tested scenarios**
<!-- Description of tested scenarios -->
Tested with mock data
