### PR TITLE
Added missing variants to manual capture list

### DIFF
--- a/src/Adyen/Util/ManualCapture.php
+++ b/src/Adyen/Util/ManualCapture.php
@@ -59,7 +59,10 @@ class ManualCapture
         'amex_applepay',
         'discover_applepay',
         'maestro_applepay',
+        'cartebancaire_applepay',
         'paywithgoogle',
+        'mc_googlepay',
+        'visa_googlepay',
         'svs',
         'givex',
         'valuelink',
@@ -74,7 +77,9 @@ class ManualCapture
         'applepay',
         'googlepay',
         'mobilepay',
-        'vipps'
+        'vipps',
+        'walley',
+        'walley_b2b'
     );
 
     public function isManualCaptureSupported($notificationPaymentMethod): bool


### PR DESCRIPTION

**Description**
Added googlepay subvariants, applepay cartesbancaires and new walley variants in manualCapture payment methods list

**Fixed issue**:  #PW-7706 #PW-8003 #PW-7706
