### PR TITLE
Allow monolog v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
-    "monolog/monolog": "^1.16 || ^2.0"
+    "monolog/monolog": "^1.16 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "0.4.0",


### PR DESCRIPTION
This lib only uses monolog to create a falllback handler to stderr. So no breaking changes for this lib, and it allows users of this lib to upgrade to v3