### PR TITLE
(Hotfix Main)[ITT-433] Fix paymentLinks endpoint URL builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the officially supported PHP library for using Adyen's APIs.
 
-[![version](https://img.shields.io/badge/version-14.0.0-blue.svg)](https://docs.adyen.com/development-resources/libraries)
+[![version](https://img.shields.io/badge/version-14.0.1-blue.svg)](https://docs.adyen.com/development-resources/libraries)
 
 ## Integration
 The library supports all APIs under the following services:

--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -10,7 +10,7 @@ use Monolog\Handler\StreamHandler;
 
 class Client
 {
-    const LIB_VERSION = "14.0.0";
+    const LIB_VERSION = "14.0.1";
     const LIB_NAME = "adyen-php-api-library";
     const USER_AGENT_SUFFIX = "adyen-php-api-library/";
     const ENDPOINT_TEST = "https://pal-test.adyen.com";
@@ -33,7 +33,7 @@ class Client
     const ENDPOINT_TERMINAL_CLOUD_LIVE = "https://terminal-api-live.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_US_LIVE = "https://terminal-api-live-us.adyen.com";
     const ENDPOINT_TERMINAL_CLOUD_AU_LIVE = "https://terminal-api-live-au.adyen.com";
-    const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com/checkout";
+    const ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com";
     const ENDPOINT_CHECKOUT_LIVE_SUFFIX = "-checkout-live.adyenpayments.com/checkout";
     const ENDPOINT_PROTOCOL = "https://";
     const ENDPOINT_NOTIFICATION_TEST = "https://cal-test.adyen.com/cal/services/Notification";
@@ -48,8 +48,8 @@ class Client
     const ENDPOINT_CUSTOMER_AREA_LIVE = "https://ca-live.adyen.com";
     const ENDPOINT_HOP_TEST = "https://cal-test.adyen.com/cal/services/Hop";
     const ENDPOINT_HOP_LIVE = "https://cal-live.adyen.com/cal/services/Hop";
-    const MANAGEMENT_API_TEST = "https://management-test.adyen.com/";
-    const MANAGEMENT_API_LIVE = "https://management-live.adyen.com/";
+    const MANAGEMENT_API_TEST = "https://management-test.adyen.com";
+    const MANAGEMENT_API_LIVE = "https://management-live.adyen.com";
     const MANAGEMENT_API = "v1";
 
     /**

--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -57,10 +57,8 @@ abstract class AbstractResource
         $this->allowApplicationInfoPOS = $allowApplicationInfoPOS;
         $this->checkoutEndpoint = $service->getClient()->getConfig()->get('endpointCheckout') . '/'
             . $service->getClient()->getApiCheckoutVersion();
-        $this->managementEndpoint = $service->getClient()->getConfig()->get('endpointManagementApi')
+        $this->managementEndpoint = $service->getClient()->getConfig()->get('endpointManagementApi') . '/'
             . $service->getClient()->getManagementApiVersion();
-        $this->checkoutEndpoint = $service->getClient()->getConfig()->get('endpointCheckout')
-            . $service->getClient()->getApiCheckoutVersion();
     }
 
     /**


### PR DESCRIPTION
**Description**
Checkout API paymentLinks endpoint fails due to wrong endpoint URL.
- paymentLinks endpoint fixed.
- Management API endpoint updated to follow same convenience
