### PR TITLE
Fix POS SaleToAcquirerData base64 encoding

### DIFF
--- a/src/Adyen/Service/AbstractResource.php
+++ b/src/Adyen/Service/AbstractResource.php
@@ -184,12 +184,12 @@ abstract class AbstractResource
             parse_str($saleToAcquirerData, $queryString);
             $queryStringValues = array_values($queryString);
 
-            //check if querystring is nonempty and contains a value
-            if (!empty($queryString) && !empty($queryStringValues[0])) {
-                $saleToAcquirerData = $queryString;
-            } elseif ($this->isBase64Encoded($saleToAcquirerData)) {
+            // Check if $saleToAcquirerData is base64 encoded or querystring is nonempty and contains a value
+            if ($this->isBase64Encoded($saleToAcquirerData)) {
                 //If SaleToAcquirerData is a base64encoded string decode it and convert it to array
                 $saleToAcquirerData = json_decode(base64_decode($saleToAcquirerData, true), true);
+            } elseif (!empty($queryString) && !empty($queryStringValues[0])) {
+                $saleToAcquirerData = $queryString;
             }
         }
 


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
If a `saleToAcquirer` object has a set a definite characters in it in a given order in base64 encoded string, PHP's in-built `parse_str()` function considers it as a query parameter array, which results in faulty modification of the original `saleToAcquirer` data. If the object is broken, POS payment attempt is rejected by terminal api with `Reason: Failed validation` error message.

In this PR, the order of the condition changed to first check if the `saleToAcquirer` data is a base64 encoded string.

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
