### PR TITLE
Remove default setting of bool

### DIFF
--- a/templates/model_generic.mustache
+++ b/templates/model_generic.mustache
@@ -242,7 +242,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
 
         {{/parentSchema}}
         {{#vars}}
-        $this->setIfExists('{{name}}', $data ?? [], {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}});
+        $this->setIfExists('{{name}}', $data ?? [], null);
         {{/vars}}
         {{#discriminator}}
 


### PR DESCRIPTION
**Description**
This fixes the default setting of bools (and removes the need for nullable bools as bools are not serialised by default unless explicitly set). Fixes: #593 #601 

Verified by regenerating checkout and parsing the bools to json. Automation will pick it up.
