### PR TITLE
Make billingToken nullable

### DIFF
--- a/src/Adyen/Model/Checkout/PaymentCompletionDetails.php
+++ b/src/Adyen/Model/Checkout/PaymentCompletionDetails.php
@@ -536,9 +536,6 @@ class PaymentCompletionDetails implements ModelInterface, ArrayAccess, \JsonSeri
      */
     public function setBillingToken($billingToken)
     {
-        if (is_null($billingToken)) {
-            throw new \InvalidArgumentException('non-nullable billingToken cannot be null');
-        }
         $this->container['billingToken'] = $billingToken;
 
         return $this;


### PR DESCRIPTION
**Description**
This change makes `billingToken` nullable, since it's required only for recurring PayPal payments.

**Fixed issue**:  #664 
