### PR TITLE
[ECP-9272] Allow Application Info in request parameters for modifications 

### DIFF
--- a/src/Adyen/Service/ResourceModel/Checkout/Cancels.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Cancels.php
@@ -14,7 +14,7 @@ class Cancels extends \Adyen\Service\AbstractCheckoutResource
      *
      * @var bool
      */
-    protected $allowApplicationInfo = false;
+    protected $allowApplicationInfo = true;
 
     /**
      * Payments constructor.

--- a/src/Adyen/Service/ResourceModel/Checkout/Captures.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Captures.php
@@ -14,7 +14,7 @@ class Captures extends \Adyen\Service\AbstractCheckoutResource
      *
      * @var bool
      */
-    protected $allowApplicationInfo = false;
+    protected $allowApplicationInfo = true;
 
     /**
      * Payments constructor.

--- a/src/Adyen/Service/ResourceModel/Checkout/Refunds.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Refunds.php
@@ -14,7 +14,7 @@ class Refunds extends \Adyen\Service\AbstractCheckoutResource
      *
      * @var bool
      */
-    protected $allowApplicationInfo = false;
+    protected $allowApplicationInfo = true;
 
     /**
      * Payments constructor.

--- a/src/Adyen/Service/ResourceModel/Checkout/Reversals.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Reversals.php
@@ -14,7 +14,7 @@ class Reversals extends \Adyen\Service\AbstractCheckoutResource
      *
      * @var bool
      */
-    protected $allowApplicationInfo = false;
+    protected $allowApplicationInfo = true;
 
     /**
      * Payments constructor.


### PR DESCRIPTION
**Description**
This PR sets the `allowApplicationInfo` field to `true` for modification request calls from plugin same as for /payments calls, with the aim of providing data on **cancel**, **capture**, **refund** and **reversal** calls in the plugin allowing more visibility on such data and possible tracking.

**Tested scenarios**
Cancel, Refund, Capture
