### PR TITLE
deprecated old HmacSignature method, adjusted unittest

### DIFF
--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -18,16 +18,16 @@ class HmacSignature
      */
     public function validateHMAC(string $hmacKey, string $hmacSign, string $webhook): bool
     {
-        if (!ctype_xdigit($hmacKey)) {
+        if (!ctype_xdigit($hmacSign)) {
             throw new AdyenException("Invalid HMAC key: $hmacKey");
         }
         $expectedSign = base64_encode(hash_hmac(
             'sha256',
             $webhook,
-            pack("H*", $hmacKey),
+            pack("H*", $hmacSign),
             true
         ));
-        return hash_equals($expectedSign, $hmacSign);
+        return hash_equals($expectedSign, $hmacKey);
     }
 
     /**

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -9,7 +9,7 @@ class HmacSignature
     const EVENT_CODE = "eventCode";
 
     /**
-     * @deprecated Use validateHMACSignature with correct parameter order instead
+     * @deprecated use Use validateHMACSignature with correct parameter order instead
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers
      * @param string $webhook The response from Adyen
@@ -29,6 +29,7 @@ class HmacSignature
         ));
         return hash_equals($expectedSign, $hmacKey);
     }
+
     /**
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -9,6 +9,7 @@ class HmacSignature
     const EVENT_CODE = "eventCode";
 
     /**
+     * @deprecated Use validateHMACVSignature with correct parameter order instead
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers
      * @param string $webhook The response from Adyen
@@ -27,6 +28,26 @@ class HmacSignature
             true
         ));
         return hash_equals($expectedSign, $hmacKey);
+    }
+    /**
+     * @param string $hmacKey Can be found in Customer Area
+     * @param string $hmacSign Can be found in the Webhook headers
+     * @param string $webhook The response from Adyen
+     * @return bool
+     * @throws AdyenException
+     */
+    public function validateHMACSignature(string $hmacKey, string $hmacSign, string $webhook): bool
+    {
+        if (!ctype_xdigit($hmacKey)) {
+            throw new AdyenException("Invalid HMAC key: $hmacKey");
+        }
+        $expectedSign = base64_encode(hash_hmac(
+            'sha256',
+            $webhook,
+            pack("H*", $hmacKey),
+            true
+        ));
+        return hash_equals($expectedSign, $hmacSign);
     }
     /**
      * @param string $hmacKey Can be found in Customer Area

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -9,7 +9,7 @@ class HmacSignature
     const EVENT_CODE = "eventCode";
 
     /**
-     * @deprecated Use validateHMACVSignature with correct parameter order instead
+     * @deprecated Use validateHMACSignature with correct parameter order instead
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers
      * @param string $webhook The response from Adyen

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -153,9 +153,30 @@ JSON
     }
 
     /**
+     * @deprecated
      * @throws AdyenException
      */
     public function testBankingWebhookHmacValidation()
+    {
+        $params = "{\"data\":{\"balancePlatform\":\"Integration_tools_test\","
+            . "\"accountId\":\"BA32272223222H5HVKTBK4MLB\",\"sweep\":{\"id\":\"SWPC42272223222H5HVKV6H8C64DP5\","
+            . "\"schedule\":{\"type\":\"balance\"},\"status\":\"active\",\"targetAmount\":{\"currency\":\"EUR\""
+            . ",\"value\":0},\"triggerAmount\":{\"currency\":\"EUR\",\"value\":0},\"type\":\"pull\",\"counterparty\":"
+            . "{\"balanceAccountId\":\"BA3227C223222H5HVKT3H9WLC\"},\"currency\":\"EUR\"}},\"environment\":"
+            . "\"test\",\"type\":\"balancePlatform.balanceAccountSweep.updated\"}";
+        $hmac = new HmacSignature();
+        $result = $hmac->validateHMAC(
+            "9Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=",
+            "D7DD5BA6146493707BF0BE7496F6404EC7A63616B7158EC927B9F54BB436765F",
+            $params
+        );
+        self::assertTrue($result);
+    }
+
+    /**
+     * @throws AdyenException
+     */
+    public function testBankingWebhookHmacSignatureValidation()
     {
         $params = "{\"data\":{\"balancePlatform\":\"Integration_tools_test\","
             . "\"accountId\":\"BA32272223222H5HVKTBK4MLB\",\"sweep\":{\"id\":\"SWPC42272223222H5HVKV6H8C64DP5\","

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -164,9 +164,9 @@ JSON
             . "{\"balanceAccountId\":\"BA3227C223222H5HVKT3H9WLC\"},\"currency\":\"EUR\"}},\"environment\":"
             . "\"test\",\"type\":\"balancePlatform.balanceAccountSweep.updated\"}";
         $hmac = new HmacSignature();
-        $result = $hmac->validateHMAC(
-            "9Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=",
+        $result = $hmac->validateHMACSignature(
             "D7DD5BA6146493707BF0BE7496F6404EC7A63616B7158EC927B9F54BB436765F",
+            "9Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=",
             $params
         );
         self::assertTrue($result);

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -151,7 +151,6 @@ JSON
             $this->fail('Unexpected exception');
         }
     }
-
     /**
      * @deprecated
      * @throws AdyenException
@@ -176,7 +175,7 @@ JSON
     /**
      * @throws AdyenException
      */
-    public function testBankingWebhookHmacSignatureValidation()
+    public function testBankingWebhookHmacSignature()
     {
         $params = "{\"data\":{\"balancePlatform\":\"Integration_tools_test\","
             . "\"accountId\":\"BA32272223222H5HVKTBK4MLB\",\"sweep\":{\"id\":\"SWPC42272223222H5HVKV6H8C64DP5\","


### PR DESCRIPTION
- Deprecated old Hmac validation method 
- updated unit test with new validateHMACSignature method.

Tested by running the unit tests
