### PR TITLE
Add deprecation info

### DIFF
--- a/templates/api-single.mustache
+++ b/templates/api-single.mustache
@@ -38,6 +38,10 @@ class {{customApi}}Api extends Service
     * Description: {{.}}
     *
     {{/description}}
+    {{#deprecated}}
+    * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
+      {{/vendorExtensions.x-deprecatedInVersion}}
+    {{/deprecated}}
     {{#pathParams}}
     * @param {{{dataType}}} ${{#lambda.camelcase}}{{paramName}}{{/lambda.camelcase}}
     {{/pathParams}}

--- a/templates/api.mustache
+++ b/templates/api.mustache
@@ -39,6 +39,10 @@ class {{classname}} extends Service
     * Description: {{.}}
     *
     {{/description}}
+    {{#deprecated}}
+    * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
+      {{/vendorExtensions.x-deprecatedInVersion}}
+    {{/deprecated}}
     {{#pathParams}}
     * @param {{{dataType}}} ${{#lambda.camelcase}}{{paramName}}{{/lambda.camelcase}}
     {{/pathParams}}

--- a/templates/model_generic.mustache
+++ b/templates/model_generic.mustache
@@ -72,6 +72,10 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * Array of nullable properties
      *
      * @return array
+     {{#deprecated}}
+     * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
+       {{/vendorExtensions.x-deprecatedInVersion}}
+     {{/deprecated}}
      */
     protected static function openAPINullables(): array
     {
@@ -325,9 +329,10 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * Gets {{name}}
      *
      * @return {{{dataType}}}{{^required}}|null{{/required}}
-    {{#deprecated}}
-     * @deprecated
-    {{/deprecated}}
+     {{#deprecated}}
+     * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
+      {{/vendorExtensions.x-deprecatedInVersion}}
+     {{/deprecated}}
      */
     public function {{getter}}()
     {
@@ -340,9 +345,10 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @param {{{dataType}}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{.}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return self
-    {{#deprecated}}
-     * @deprecated
-    {{/deprecated}}
+     {{#deprecated}}
+     * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
+       {{/vendorExtensions.x-deprecatedInVersion}}
+     {{/deprecated}}
      */
     public function {{setter}}(${{name}})
     {


### PR DESCRIPTION
**Description**
This PR improves the mustache templates by adding the additional information (`deprecationInVersion`, `deprecationMessage`) to deprecated models and services. The info is displayed only when at least`x-deprecatedInVersion` is available. Else, only the deprecation tag is displayed.

**Tested scenarios**
- Ran the adyen-sdk-automation against the adyen-php-library to verify expected output.

### Example
Before:
```
* @deprecated
```

After:
```
* @deprecated  since Configuration API v2. "Please use `bankAccount` object instead"
```