### PR TITLE
Add deprecation info for services

### DIFF
--- a/templates/api.mustache
+++ b/templates/api.mustache
@@ -39,10 +39,10 @@ class {{classname}} extends Service
     * Description: {{.}}
     *
     {{/description}}
-    {{#deprecated}}
+    {{#isDeprecated}}
     * @deprecated {{^vendorExtensions.x-deprecatedInVersion}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedInVersion}} since {{#appName}}{{{.}}}{{/appName}} v{{.}}. {{#vendorExtensions.x-deprecatedMessage}}"{{{.}}}"{{/vendorExtensions.x-deprecatedMessage}}
       {{/vendorExtensions.x-deprecatedInVersion}}
-    {{/deprecated}}
+    {{/isDeprecated}}
     {{#pathParams}}
     * @param {{{dataType}}} ${{#lambda.camelcase}}{{paramName}}{{/lambda.camelcase}}
     {{/pathParams}}


### PR DESCRIPTION
**Description**
This PR fixes the mustache templates by adding the additional information (`deprecationInVersion`, `deprecationMessage`) to deprecated `services`. The info is displayed only when at least`x-deprecatedInVersion` is available. Else, only the deprecation tag is displayed.

Relates to PR #735 

**Tested scenarios**
- Ran the `adyen-sdk-automation` against the `adyen-php-library` to verify expected output.