### PR TITLE
HMAC Troubleshooting tool

### DIFF
--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -42,12 +42,7 @@ class HmacSignature
         if (!ctype_xdigit($hmacKey)) {
             throw new AdyenException("Invalid HMAC key: $hmacKey");
         }
-        $expectedSign = base64_encode(hash_hmac(
-            'sha256',
-            $webhook,
-            pack("H*", $hmacKey),
-            true
-        ));
+        $expectedSign = self::calculateHmacSignature($hmacKey, $webhook);
         return hash_equals($expectedSign, $hmacSign);
     }
     /**
@@ -76,7 +71,7 @@ class HmacSignature
 
 
         // base64-encode the binary result of the HMAC computation
-        $merchantSig = base64_encode(hash_hmac('sha256', $dataToSign, pack("H*", $hmacKey), true));
+        $merchantSig = self::calculateHmacSignature($hmacKey, $dataToSign);
         return $merchantSig;
     }
 
@@ -180,4 +175,25 @@ class HmacSignature
         );
         return array_key_exists(self::EVENT_CODE, $response) && in_array($response[self::EVENT_CODE], $eventCodes);
     }
+
+    /**
+    * Calculate HMAC signature
+    *
+    * @param string $hmacKey Can be found in Customer Area
+    * @param string $payload The response from Adyen
+    * @return string
+    * @throws AdyenException
+    */
+    public function calculateHmacSignature(string $hmacKey, string $payload): string
+    {
+        if (empty($hmacKey)) {
+        throw new AdyenException("You did not provide a HMAC key");
+        }
+
+        if (!ctype_xdigit($hmacKey)) {
+            throw new AdyenException("Invalid HMAC key: $hmacKey");
+        }
+
+        return base64_encode(hash_hmac('sha256', $payload, pack("H*", $hmacKey), true));
+    }    
 }

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -37,7 +37,7 @@ class HmacSignature
      *
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers
-     * @param string $webhook The webhook payload 
+     * @param string $webhook The webhook payload
      * @return bool
      * @throws AdyenException
      */
@@ -196,7 +196,7 @@ class HmacSignature
     public function calculateHmacSignature(string $hmacKey, string $payload): string
     {
         if (empty($hmacKey)) {
-        throw new AdyenException("You did not provide a HMAC key");
+            throw new AdyenException("You did not provide a HMAC key");
         }
 
         if (!ctype_xdigit($hmacKey)) {
@@ -204,5 +204,5 @@ class HmacSignature
         }
 
         return base64_encode(hash_hmac('sha256', $payload, pack("H*", $hmacKey), true));
-    }    
+    }
 }

--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -31,9 +31,13 @@ class HmacSignature
     }
 
     /**
+     * Validate the HMAC Signature of the webhook payload
+     * Used for BankingWebhooks and ManagementWebhooks (where HMAC signature is provided in the HTTP header)
+     * Note: HMAC signature is calculated considering the entire payload
+     *
      * @param string $hmacKey Can be found in Customer Area
      * @param string $hmacSign Can be found in the Webhook headers
-     * @param string $webhook The response from Adyen
+     * @param string $webhook The webhook payload 
      * @return bool
      * @throws AdyenException
      */
@@ -46,8 +50,9 @@ class HmacSignature
         return hash_equals($expectedSign, $hmacSign);
     }
     /**
+     * Calculate HMAC Signature for Payments webhooks
      * @param string $hmacKey Can be found in Customer Area
-     * @param array $params The response from Adyen
+     * @param array $params NotificationRequestItem object inside the webhook payload
      * @return string
      * @throws AdyenException
      */
@@ -106,6 +111,10 @@ class HmacSignature
     }
 
     /**
+     * Validate the HMAC Signature of the requestItem object included in the webhook payload
+     * Used for Payment Webhooks (where HMAC signature is provided in the `additionalData` field)
+     * Note: HMAC signature is calculated considering a subset of the fields (see `calculateNotificationHMAC` function)
+     *
      * @param string $hmacKey
      * @param array $params
      * @return bool

--- a/tools/hmac/HMACValidator.php
+++ b/tools/hmac/HMACValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+// script to calculate the HMAC signature using the PHP library `calculateHmacSignature` function
+//
+// Run with: `php tools/hmac/HMACValidator.php {hmacKey} {path to JSON file}
+// php tools/hmac/HMACValidator.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Adyen\Util\HmacSignature;
+
+if ($argc !== 3) {
+    echo "Usage: php calculate_hmac.php <hmacKey> <payloadFile>\n";
+    exit(1);
+}
+
+$hmacKey = $argv[1];
+$payloadFile = $argv[2];
+
+if (!file_exists($payloadFile)) {
+    echo "Error: File '$payloadFile' not found.\n";
+    exit(1);
+}
+
+echo "Calculating HMAC signature with payload from '$payloadFile'\n";
+
+// load payload
+$payload = file_get_contents($payloadFile);
+
+$hmacSignature = new HmacSignature();
+$signature = $hmacSignature->calculateHmacSignature($hmacKey, $payload);
+
+echo "HMAC Signature-> $signature\n";
+exit(0);

--- a/tools/hmac/HMACValidatorBanking.php
+++ b/tools/hmac/HMACValidatorBanking.php
@@ -1,9 +1,10 @@
 <?php
 
-// script to calculate the HMAC signature using the PHP library `calculateHmacSignature` function
+// script to calculate the HMAC signature of Banking/Management webhooks (where the signature is calculated over the
+// entire webhook payload)
 //
-// Run with: `php tools/hmac/HMACValidator.php {hmacKey} {path to JSON file}
-// php tools/hmac/HMACValidator.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+// Run with: `php tools/hmac/HMACValidatorBanking.php {hmacKey} {path to JSON file}
+// php tools/hmac/HMACValidatorBanking.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload2.json
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 

--- a/tools/hmac/HMACValidatorBanking.php
+++ b/tools/hmac/HMACValidatorBanking.php
@@ -4,7 +4,7 @@
 // entire webhook payload)
 //
 // Run with: `php tools/hmac/HMACValidatorBanking.php {hmacKey} {path to JSON file}
-// php tools/hmac/HMACValidatorBanking.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload2.json
+// php tools/hmac/HMACValidatorBanking.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload2.json
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 

--- a/tools/hmac/HMACValidatorBanking.php
+++ b/tools/hmac/HMACValidatorBanking.php
@@ -11,9 +11,11 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use Adyen\Util\HmacSignature;
 
 if ($argc !== 3) {
-    echo "Usage: php calculate_hmac.php <hmacKey> <payloadFile>\n";
+    echo "‼️Error running the script\n";
+    echo "Usage: php HMACValidatorBanking.php <hmacKey> <payloadFile>\n";
     exit(1);
 }
+
 
 $hmacKey = $argv[1];
 $payloadFile = $argv[2];
@@ -23,10 +25,13 @@ if (!file_exists($payloadFile)) {
     exit(1);
 }
 
-echo "Calculating HMAC signature with payload from '$payloadFile'\n";
-
 // load payload
 $payload = file_get_contents($payloadFile);
+
+echo "Calculating HMAC signature with payload from '$payloadFile'\n";
+echo "********\n";
+echo "Payload file: '$payloadFile'\n";
+echo "Payload length: " . strlen($payload) . "\n";
 
 $hmacSignature = new HmacSignature();
 $signature = $hmacSignature->calculateHmacSignature($hmacKey, $payload);

--- a/tools/hmac/HMACValidatorPayments.php
+++ b/tools/hmac/HMACValidatorPayments.php
@@ -1,0 +1,40 @@
+<?php
+
+// script to calculate the HMAC signature of Payments webhooks (where the signature is calculated considering
+// a subset of the fields in the payload - i.e. NotificationRequestItem object)
+//
+// Run with: `php tools/hmac/HMACValidatorPayments.php {hmacKey} {path to JSON file}
+// php tools/hmac/HMACValidatorPayments.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Adyen\Util\HmacSignature;
+
+if ($argc !== 3) {
+    echo "Usage: php calculate_hmac.php <hmacKey> <payloadFile>\n";
+    exit(1);
+}
+
+$hmacKey = $argv[1];
+$payloadFile = $argv[2];
+
+if (!file_exists($payloadFile)) {
+    echo "Error: File '$payloadFile' not found.\n";
+    exit(1);
+}
+
+echo "Calculating HMAC signature with payload from '$payloadFile'\n";
+
+// load payload as JSON
+$payload = file_get_contents($payloadFile);
+$payload = json_decode($payload, true);
+
+// Fetch the first (and only) NotificationRequestItem
+$notificationItems = $payload['notificationItems'];
+$notificationRequestItem = array_shift($notificationItems);
+
+$hmacSignature = new HmacSignature();
+$signature = $hmacSignature->calculateNotificationHMAC($hmacKey, $notificationRequestItem);
+
+echo "HMAC Signature-> $signature\n";
+exit(0);

--- a/tools/hmac/HMACValidatorPayments.php
+++ b/tools/hmac/HMACValidatorPayments.php
@@ -4,7 +4,7 @@
 // a subset of the fields in the payload - i.e. NotificationRequestItem object)
 //
 // Run with: `php tools/hmac/HMACValidatorPayments.php {hmacKey} {path to JSON file}
-// php tools/hmac/HMACValidatorPayments.php 51757397D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+// php tools/hmac/HMACValidatorPayments.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 

--- a/tools/hmac/HMACValidatorPayments.php
+++ b/tools/hmac/HMACValidatorPayments.php
@@ -27,11 +27,28 @@ echo "Calculating HMAC signature with payload from '$payloadFile'\n";
 
 // load payload as JSON
 $payload = file_get_contents($payloadFile);
-$payload = json_decode($payload, true);
+$jsonData = json_decode($payload, true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    echo "Error: Invalid JSON in payload file.\n";
+    exit(1);
+}
+
+if (!isset($jsonData['notificationItems']) || !is_array($jsonData['notificationItems'])) {
+    echo "Error: 'notificationItems' key is missing or not an array.\n";
+    exit(1);
+}
 
 // Fetch the first (and only) NotificationRequestItem
-$notificationItems = $payload['notificationItems'];
-$notificationRequestItem = array_shift($notificationItems);
+$notificationRequestItem = $jsonData['notificationItems'][0]['NotificationRequestItem'] ?? null;
+
+if ($notificationRequestItem === null) {
+    echo "Error: 'NotificationRequestItem' is not found.\n";
+    exit(1);
+}
+
+// Log notificationRequestItem
+//print_r($notificationRequestItem);
 
 $hmacSignature = new HmacSignature();
 $signature = $hmacSignature->calculateNotificationHMAC($hmacKey, $notificationRequestItem);

--- a/tools/hmac/HMACValidatorPayments.php
+++ b/tools/hmac/HMACValidatorPayments.php
@@ -11,7 +11,8 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use Adyen\Util\HmacSignature;
 
 if ($argc !== 3) {
-    echo "Usage: php calculate_hmac.php <hmacKey> <payloadFile>\n";
+    echo "‼️Error running the script\n";
+    echo "Usage: php HMACValidatorPayments.php <hmacKey> <payloadFile>\n";
     exit(1);
 }
 
@@ -22,8 +23,6 @@ if (!file_exists($payloadFile)) {
     echo "Error: File '$payloadFile' not found.\n";
     exit(1);
 }
-
-echo "Calculating HMAC signature with payload from '$payloadFile'\n";
 
 // load payload as JSON
 $payload = file_get_contents($payloadFile);
@@ -46,6 +45,12 @@ if ($notificationRequestItem === null) {
     echo "Error: 'NotificationRequestItem' is not found.\n";
     exit(1);
 }
+
+echo "Calculating HMAC signature with payload from '$payloadFile'\n";
+echo "********\n";
+echo "Payload file: '$payloadFile'\n";
+echo "Payload length: " . strlen($payload) . "\n";
+
 
 // Log notificationRequestItem
 //print_r($notificationRequestItem);

--- a/tools/hmac/README.md
+++ b/tools/hmac/README.md
@@ -8,7 +8,7 @@ Note: make sure you are using the HMAC key used to generate the signature associ
 ### Payments webhooks
 
 Copy the content of the webhook in the payload.json (or provide a different file), then run with: 
-`php tools/hmac/HMACValidatorPayments.php {hmacKey} {path to JSON file}
+`php tools/hmac/HMACValidatorPayments.php {hmacKey} {path to JSON file}`
 ```
 php tools/hmac/HMACValidatorPayments.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
 ```
@@ -16,7 +16,7 @@ php tools/hmac/HMACValidatorPayments.php 11223344D785FBAE710E7F943F307971BB61B21
 ### Banking webhooks
 
 Copy the content of the webhook in the payload2.json (or provide a different file), then run with: 
-`php tools/hmac/HMACValidatorBanking.php {hmacKey} {path to JSON file}
+`php tools/hmac/HMACValidatorBanking.php {hmacKey} {path to JSON file}`
 ```
 php tools/hmac/HMACValidatorBanking.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload2.json
 ```

--- a/tools/hmac/README.md
+++ b/tools/hmac/README.md
@@ -3,6 +3,8 @@
 This folder contains PHP scripts to calculate the HMAC signature of the webhook payload.  
 They can be used to troubleshoot the HMAC signature calculation.
 
+Note: make sure you are using the HMAC key used to generate the signature associated with the payload in the JSON file
+
 ### Payments webhooks
 
 Copy the content of the webhook in the payload.json (or provide a different file), then run with: 

--- a/tools/hmac/README.md
+++ b/tools/hmac/README.md
@@ -1,9 +1,20 @@
 ## HMAC Tools
 
-Use HMACValidator to calculate the HMAC signature of a payload (i.e. troubleshooting of the HMAC signature calculation)
+This folder contains PHP scripts to calculate the HMAC signature of the webhook payload.  
+They can be used to troubleshoot the HMAC signature calculation.
 
+### Payments webhooks
 
-Run with: `php tools/hmac/HMACValidator.php {hmacKey} {path to JSON file}
+Copy the content of the webhook in the payload.json (or provide a different file), then run with: 
+`php tools/hmac/HMACValidatorPayments.php {hmacKey} {path to JSON file}
 ```
-php tools/hmac/HMACValidator.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+php tools/hmac/HMACValidatorPayments.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+```
+
+### Banking webhooks
+
+Copy the content of the webhook in the payload2.json (or provide a different file), then run with: 
+`php tools/hmac/HMACValidatorBanking.php {hmacKey} {path to JSON file}
+```
+php tools/hmac/HMACValidatorBanking.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload2.json
 ```

--- a/tools/hmac/README.md
+++ b/tools/hmac/README.md
@@ -1,0 +1,9 @@
+## HMAC Tools
+
+Use HMACValidator to calculate the HMAC signature of a payload (i.e. troubleshooting of the HMAC signature calculation)
+
+
+Run with: `php tools/hmac/HMACValidator.php {hmacKey} {path to JSON file}
+```
+php tools/hmac/HMACValidator.php 11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB tools/hmac/payload.json
+```

--- a/tools/hmac/payload.json
+++ b/tools/hmac/payload.json
@@ -5,7 +5,7 @@
             "NotificationRequestItem": {
                 "additionalData": {
                     "cardSummary": "0010",
-                    "hmacSignature": "eEPKSnC7WYakDGfgnf2R8dH7briE2ljZ\/C9133CZcfQ=",
+                    "hmacSignature": "e7qQumH1fdt5NHb6e62jq6hIGUCpfhAAFXhUXqXcJAQ=",
                     "expiryDate": "03\/2030",
                     "recurring.contractTypes": "ONECLICK,RECURRING",
                     "cardBin": "222241",

--- a/tools/hmac/payload.json
+++ b/tools/hmac/payload.json
@@ -1,0 +1,54 @@
+{
+    "live": "false",
+    "notificationItems": [
+        {
+            "NotificationRequestItem": {
+                "additionalData": {
+                    "cardSummary": "0010",
+                    "hmacSignature": "eEPKSnC7WYakDGfgnf2R8dH7briE2ljZ\/C9133CZcfQ=",
+                    "expiryDate": "03\/2030",
+                    "recurring.contractTypes": "ONECLICK,RECURRING",
+                    "cardBin": "222241",
+                    "recurring.recurringDetailReference": "DQWW2BQ9FX2R7475",
+                    "recurringProcessingModel": "Subscription",
+                    "metadata.orderTransactionId": "63",
+                    "alias": "F758505419855455",
+                    "paymentMethodVariant": "m1",
+                    "acquirerReference": "JQBMF3P3FJM",
+                    "issuerBin": "22224107",
+                    "cardIssuingCountry": "NL",
+                    "authCode": "060494",
+                    "cardHolderName": "Checkout Test",
+                    "PaymentAccountReference": "Jj3gVfMpPcpKzmHrHmpxqgfsvGaVa",
+                    "checkout.cardAddedBrand": "mc",
+                    "store": "None",
+                    "tokenization.shopperReference": "4d74f0727a318b13f85aee28ae556a08d7d9cf9e6d67b70a62e60e334aa7090d",
+                    "recurring.firstPspReference": "P9M9CTGJKKKKP275",
+                    "tokenization.storedPaymentMethodId": "DQWW2BQ9FX2R7475",
+                    "issuerCountry": "NL",
+                    "aliasType": "Default",
+                    "paymentMethod": "mc",
+                    "recurring.shopperReference": "4d74f0727a318b13f85aee28ae556a08d7d9cf9e6d67b70a62e60e334aa7090d",
+                    "cardPaymentMethod": "mc2"
+                },
+                "amount": {
+                    "currency": "EUR",
+                    "value": 32500
+                },
+                "eventCode": "AUTHORISATION",
+                "eventDate": "2025-02-24T15:20:56+01:00",
+                "merchantAccountCode": "Merchant 1",
+                "merchantReference": "1143-R2",
+                "operations": [
+                    "CANCEL",
+                    "CAPTURE",
+                    "REFUND"
+                ],
+                "paymentMethod": "mc",
+                "pspReference": "AB1234567890",
+                "reason": "060494:0010:03\/2030",
+                "success": "true"
+            }
+        }
+    ]
+}

--- a/tools/hmac/payload.json
+++ b/tools/hmac/payload.json
@@ -5,7 +5,7 @@
             "NotificationRequestItem": {
                 "additionalData": {
                     "cardSummary": "0010",
-                    "hmacSignature": "e7qQumH1fdt5NHb6e62jq6hIGUCpfhAAFXhUXqXcJAQ=",
+                    "hmacSignature": "qHNSvxCCix79xgBdWemxf0rcNMWoLrMK/4IgMnkOsWI=",
                     "expiryDate": "03\/2030",
                     "recurring.contractTypes": "ONECLICK,RECURRING",
                     "cardBin": "222241",

--- a/tools/hmac/payload2.json
+++ b/tools/hmac/payload2.json
@@ -1,29 +1,61 @@
 {
-    "live": "false",
-    "notificationItems": [
-        {
-            "NotificationRequestItem": {
-                "additionalData": {
-                    "metadata.orderTransactionId": "63",
-                    "bookingDate": "2025-02-24T15:21:41Z",
-                    "paymentMethodVariant": "mc",
-                    "store": "Store Amsterdam",
-                    "hmacSignature": "1mSRodZGRNebcLHRXqGxCVa9bbCupkyHkcEUj51wves="
-                },
-                "amount": {
-                    "currency": "EUR",
-                    "value": 32500
-                },
-                "eventCode": "CAPTURE",
-                "eventDate": "2025-02-24T15:21:00+01:00",
-                "merchantAccountCode": "Merchant 1",
-                "merchantReference": "1143-R2",
-                "originalReference": "AB1234567890",
-                "paymentMethod": "mc",
-                "pspReference": "LR1234567890",
-                "reason": "",
-                "success": "true"
-            }
-        }
-    ]
-}
+    "data": {
+      "balancePlatform": "YOUR_BALANCE_PLATFORM",
+      "accountHolder": {
+        "contactDetails": {
+          "email": "test@adyen.com",
+          "phone": {
+            "number": "0612345678",
+            "type": "mobile"
+          },
+          "address": {
+            "houseNumberOrName": "23",
+            "city": "Amsterdam",
+            "country": "NL",
+            "postalCode": "12345",
+            "street": "Main Street 1"
+          }
+        },
+        "description": "Shelly Eller",
+        "legalEntityId": "LE00000000000000000001",
+        "reference": "YOUR_REFERENCE-2412C",
+        "capabilities": {
+          "issueCard": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "receiveFromTransferInstrument": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "sendToTransferInstrument": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "sendToBalanceAccount": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "receiveFromBalanceAccount": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          }
+        },
+        "id": "AH00000000000000000001",
+        "status": "active"
+      }
+    },
+    "environment": "test",
+    "timestamp": "2024-12-15T15:42:03+01:00",
+    "type": "balancePlatform.accountHolder.created"
+  }

--- a/tools/hmac/payload2.json
+++ b/tools/hmac/payload2.json
@@ -1,0 +1,29 @@
+{
+    "live": "false",
+    "notificationItems": [
+        {
+            "NotificationRequestItem": {
+                "additionalData": {
+                    "metadata.orderTransactionId": "63",
+                    "bookingDate": "2025-02-24T15:21:41Z",
+                    "paymentMethodVariant": "mc",
+                    "store": "Store Amsterdam",
+                    "hmacSignature": "1mSRodZGRNebcLHRXqGxCVa9bbCupkyHkcEUj51wves="
+                },
+                "amount": {
+                    "currency": "EUR",
+                    "value": 32500
+                },
+                "eventCode": "CAPTURE",
+                "eventDate": "2025-02-24T15:21:00+01:00",
+                "merchantAccountCode": "Merchant 1",
+                "merchantReference": "1143-R2",
+                "originalReference": "AB1234567890",
+                "paymentMethod": "mc",
+                "pspReference": "LR1234567890",
+                "reason": "",
+                "success": "true"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add scripts in `tools/hmac` to troubleshoot the HMAC signature computation of the PHP library