### PR TITLE
[DR-1284] Add CURLOPT_CONNECTTIMEOUT setting and define default values for timeouts

### DIFF
--- a/src/Adyen/Client.php
+++ b/src/Adyen/Client.php
@@ -49,6 +49,8 @@ class Client
     const MANAGEMENT_API_TEST = "https://management-test.adyen.com";
     const MANAGEMENT_API_LIVE = "https://management-live.adyen.com";
     const MANAGEMENT_API = "v1";
+    const DEFAULT_CURLOPT_TIMEOUT = 60;
+    const DEFAULT_CURLOPT_CONNECTTIMEOUT = 30;
 
     /**
      * @var Config
@@ -297,6 +299,14 @@ class Client
     public function setTimeout($value)
     {
         $this->config->set('timeout', $value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setConnectionTimeout($value)
+    {
+        $this->config->set('connectionTimeout', $value);
     }
 
     /**

--- a/src/Adyen/Config.php
+++ b/src/Adyen/Config.php
@@ -141,7 +141,19 @@ class Config
      */
     public function getTimeout()
     {
-        return !empty($this->data['timeout']) ? $this->data['timeout'] : null;
+        return !empty($this->data['timeout']) ?
+            $this->data['timeout'] :
+            Client::DEFAULT_CURLOPT_TIMEOUT;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getConnectionTimeout()
+    {
+        return !empty($this->data['connectionTimeout']) ?
+            $this->data['connectionTimeout'] :
+            Client::DEFAULT_CURLOPT_CONNECTTIMEOUT;
     }
 
     /**

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -336,6 +336,11 @@ class CurlClient implements ClientInterface
             curl_setopt($ch, CURLOPT_TIMEOUT, $config->getTimeout());
         }
 
+        // Set the connection timeout
+        if ($config->getConnectionTimeout() != null) {
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $config->getConnectionTimeout());
+        }
+
         // Set the headers
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 

--- a/tests/Unit/TestCaseMock.php
+++ b/tests/Unit/TestCaseMock.php
@@ -32,6 +32,8 @@ class TestCaseMock extends TestCase
         $client->setApplicationName("My Test Application");
         $client->setEnvironment($environment);
         $client->setXApiKey("MockAPIKey");
+        $client->setTimeout(60);
+        $client->setConnectionTimeout(30);
 
         $json = null;
         if ($jsonFile != null) {


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR add a new configuration for HTTP client to set `CURLOPT_CONNECTTIMEOUT` and defines default values for `CURLOPT_CONNECTTIMEOUT` and `CURLOPT_TIMEOUT` settings of the client.

**Tested scenarios**
<!-- Description of tested scenarios -->
- Polling `/paymentMethods` endpoint with different network settings vs client configurations 