### PR TITLE
Correct PosSdk (PosMobileService) LIVE url

### DIFF
--- a/src/Adyen/Service.php
+++ b/src/Adyen/Service.php
@@ -135,12 +135,21 @@ class Service
                     );
                 }
 
-                // We inject the live prefix like "https://{PREFIX}-"
-                $url = str_replace(
-                    "https://checkout-test.adyen.com/",
-                    "https://" . $config->get('prefix') . '-checkout-live.adyenpayments.com/checkout/',
-                    $url
-                );
+                if (strpos($url, "possdk") !== false) {
+                    // PosSdk (PosMobileApi): inject the live prefix like "https://{PREFIX}-" without duplicating `/checkout` in path
+                    $url = str_replace(
+                        "https://checkout-test.adyen.com/",
+                        "https://" . $config->get('prefix') . '-checkout-live.adyenpayments.com/',
+                        $url
+                    );                    
+                } else {
+                    // Other services: inject the live prefix like "https://{PREFIX}-"
+                    $url = str_replace(
+                        "https://checkout-test.adyen.com/",
+                        "https://" . $config->get('prefix') . '-checkout-live.adyenpayments.com/checkout/',
+                        $url
+                    );                    
+                }
             }
 
             // Replace 'test' in string with 'live' for the other endpoints

--- a/src/Adyen/Service.php
+++ b/src/Adyen/Service.php
@@ -141,14 +141,14 @@ class Service
                         "https://checkout-test.adyen.com/",
                         "https://" . $config->get('prefix') . '-checkout-live.adyenpayments.com/',
                         $url
-                    );                    
+                    );
                 } else {
                     // Other services: inject the live prefix like "https://{PREFIX}-"
                     $url = str_replace(
                         "https://checkout-test.adyen.com/",
                         "https://" . $config->get('prefix') . '-checkout-live.adyenpayments.com/checkout/',
                         $url
-                    );                    
+                    );
                 }
             }
 

--- a/tests/Resources/PosMobileApp/create-auth-session.json
+++ b/tests/Resources/PosMobileApp/create-auth-session.json
@@ -1,0 +1,7 @@
+{
+  "id": "APP_SESSION_ID",
+  "installationId": "INSTALLATION_ID",
+  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+  "store": "YOUR_STORE_ID",
+  "sdkData": "SDK_DATA_BLOB"
+}

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Adyen\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Adyen\Client;
+use Adyen\Environment;
+
+class ClientTest extends TestCase
+{
+
+    public function testCreate(): void
+    {
+        $client = new Client();
+        $client->setApplicationName("My Test Application");
+        $client->setEnvironment(Environment::TEST);
+        $client->setXApiKey("MockAPIKey");
+        $client->setTimeout(60);
+        $client->setConnectionTimeout(30);
+
+        $this->assertEquals(
+            "test",
+            $client->getConfig()->getEnvironment()
+        );
+    }
+
+    public function testCreateWithLivePrefix(): void
+    {
+        $client = new Client();
+        $client->setEnvironment(Environment::LIVE);
+        $client->setXApiKey("MockAPIKey");
+
+        // check LIVE Terminal API url
+        $this->assertEquals(
+            "https://terminal-api-live.adyen.com",
+            $client->getConfig()->get('endpointTerminalCloud')
+        );
+
+    }
+
+    public function testCreateWithInvalidPrefix(): void
+    {
+        // check an exception is thrown
+        $this->expectException(\Adyen\AdyenException::class);
+
+        $client = new Client();
+        $client->setEnvironment("Invalid");
+        $client->setXApiKey("MockAPIKey");
+    }
+
+}

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -35,7 +35,6 @@ class ClientTest extends TestCase
             "https://terminal-api-live.adyen.com",
             $client->getConfig()->get('endpointTerminalCloud')
         );
-
     }
 
     public function testCreateWithInvalidPrefix(): void
@@ -47,5 +46,4 @@ class ClientTest extends TestCase
         $client->setEnvironment("Invalid");
         $client->setXApiKey("MockAPIKey");
     }
-
 }

--- a/tests/Unit/PosMobileApiTest.php
+++ b/tests/Unit/PosMobileApiTest.php
@@ -45,5 +45,4 @@ class PosMobileApiTest extends TestCaseMock
             array('tests/Resources/PosMobileApp/create-auth-session.json', 200),
         );
     }
-   
 }

--- a/tests/Unit/PosMobileApiTest.php
+++ b/tests/Unit/PosMobileApiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Adyen\Tests\Unit;
+
+use Adyen\Service\PosMobileApi;
+use Adyen\Model\PosMobile\CreateSessionRequest;
+use Adyen\Environment;
+
+class PosMobileApiTest extends TestCaseMock
+{
+
+    /**
+     * @param $jsonFile
+     * @param $httpStatus
+     * @dataProvider posMobileApiProvider
+     * @throws \Adyen\AdyenException
+     */
+    public function testCreateCommunicationSessionSuccess($jsonFile, $httpStatus): void
+    {
+        // create client
+        $client = $this->createMockClient($jsonFile, $httpStatus, $environment = Environment::LIVE);
+
+
+        // initialize service
+        $service = new PosMobileApi($client);
+
+        $json = '{
+            "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+            "setupToken": "SETUP_TOKEN",
+            "store": "YOUR_STORE_ID"
+        }';
+
+        //$params = json_decode($json, true);
+        $params = new CreateSessionRequest(json_decode($json, true));
+
+        $result = $service->createCommunicationSession($params);
+
+        $this->assertEquals('APP_SESSION_ID', $result->getId());
+    }
+
+   
+    public static function posMobileApiProvider()
+    {
+        return array(
+            array('tests/Resources/PosMobileApp/create-auth-session.json', 200),
+        );
+    }
+   
+}

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -57,4 +57,44 @@ class ServiceTest extends TestCaseMock
         $url = $service->createBaseUrl("https://kyc-test.adyen.com/lem/v3/legalEntities");
         self::assertEquals("https://kyc-live.adyen.com/lem/v3/legalEntities", $url);
     }
+
+    // test PosMobileApi LIVE url with prefix
+    public function testLiveURLPosSdkWithPrefix()
+    {
+        $client = new Client();
+        $client->setEnvironment(Environment::LIVE, "myCompany");
+        $service = new Service($client);
+        $url = $service->createBaseUrl("https://checkout-test.adyen.com/checkout/possdk/v68");
+        self::assertEquals(
+            "https://myCompany-checkout-live.adyenpayments.com/checkout/possdk/v68",
+            $url
+        );
+    }
+
+    // test PosMobileApi TEST url without prefx
+    public function testTestURLPosSdk()
+    {
+        $client = new Client();
+        $client->setEnvironment(Environment::TEST);
+        $service = new Service($client);
+        $url = $service->createBaseUrl("https://checkout-test.adyen.com/checkout/possdk/v68");
+        self::assertEquals(
+            "https://checkout-test.adyen.com/checkout/possdk/v68",
+            $url
+        );
+    }
+
+    // test PosMobileApi TEST url with prefix
+    public function testTestURLPosSdkWithPrefix()
+    {
+        $client = new Client();
+        $client->setEnvironment(Environment::TEST, "myCompany");
+        $service = new Service($client);
+        $url = $service->createBaseUrl("https://checkout-test.adyen.com/checkout/possdk/v68");
+        // check prefix is ignored on TEST
+        self::assertEquals(
+            "https://checkout-test.adyen.com/checkout/possdk/v68",
+            $url
+        );
+    }
 }


### PR DESCRIPTION
Correct `Live` URL for PosSdk (PosMobileApi).

Fix #759  