### PR TITLE
Remove invalid PHPDoc tag @description

### DIFF
--- a/templates/model.mustache
+++ b/templates/model.mustache
@@ -18,7 +18,7 @@ use {{modelPackage}}\ObjectSerializer;
  *
  * @category Class
 {{#description}}
- * @description {{.}}
+ * {{.}}
 {{/description}}
  * @package  {{packageName}}
  * @author   OpenAPI Generator team


### PR DESCRIPTION
Update Mustache template to remove `@description` as it is not a valid PhpDoc annotation.

The code must be re-generated once this PR is merged.

Fix #757 