### PR TITLE
Fix warning: Implicitly marking parameter $params as nullable is deprecated

### DIFF
--- a/src/Adyen/AdyenException.php
+++ b/src/Adyen/AdyenException.php
@@ -40,7 +40,7 @@ class AdyenException extends Exception
     public function __construct(
         $message = "",
         $code = 0,
-        \Throwable $previous = null,
+        ?\Throwable $previous = null,
         $status = null,
         $errorType = null,
         $pspReference = null,


### PR DESCRIPTION
Mark explicitly parameters with a null default as `?Type` if they are typed.

Fix #768 