### PR TITLE
Add tests for unknown enums and attributes

### DIFF
--- a/tests/Resources/BalancePlatform/get-account-holder-additional-attributes.json
+++ b/tests/Resources/BalancePlatform/get-account-holder-additional-attributes.json
@@ -1,0 +1,44 @@
+{
+  "balancePlatform": "YOUR_BALANCE_PLATFORM",
+  "description": "Account holder used for international payments and payouts",
+  "legalEntityId": "LE322JV223222D5GG42KN6869",
+  "reference": "S.Eller-001",
+  "additionalAttributes": "something",
+  "capabilities": {
+    "receiveFromPlatformPayments": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "receiveFromBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToTransferInstrument": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "transferInstruments": [
+        {
+          "enabled": true,
+          "requested": true,
+          "allowed": false,
+          "id": "SE322KH223222F5GXZFNM3BGP",
+          "verificationStatus": "pending"
+        }
+      ],
+      "verificationStatus": "pending"
+    }
+  },
+  "id": "AH3227C223222C5GXQXF658WB",
+  "status": "active"
+}

--- a/tests/Resources/BalancePlatform/get-account-holder-unknown-enum.json
+++ b/tests/Resources/BalancePlatform/get-account-holder-unknown-enum.json
@@ -1,0 +1,43 @@
+{
+  "balancePlatform": "YOUR_BALANCE_PLATFORM",
+  "description": "Account holder used for international payments and payouts",
+  "legalEntityId": "LE322JV223222D5GG42KN6869",
+  "reference": "S.Eller-001",
+  "capabilities": {
+    "receiveFromPlatformPayments": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "this is unknown"
+    },
+    "receiveFromBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToTransferInstrument": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "transferInstruments": [
+        {
+          "enabled": true,
+          "requested": true,
+          "allowed": false,
+          "id": "SE322KH223222F5GXZFNM3BGP",
+          "verificationStatus": "pending"
+        }
+      ],
+      "verificationStatus": "pending"
+    }
+  },
+  "id": "AH3227C223222C5GXQXF658WB",
+  "status": "active"
+}

--- a/tests/Resources/BalancePlatform/get-account-holder.json
+++ b/tests/Resources/BalancePlatform/get-account-holder.json
@@ -1,0 +1,43 @@
+{
+  "balancePlatform": "YOUR_BALANCE_PLATFORM",
+  "description": "Account holder used for international payments and payouts",
+  "legalEntityId": "LE322JV223222D5GG42KN6869",
+  "reference": "S.Eller-001",
+  "capabilities": {
+    "receiveFromPlatformPayments": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "receiveFromBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToBalanceAccount": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "verificationStatus": "pending"
+    },
+    "sendToTransferInstrument": {
+      "enabled": true,
+      "requested": true,
+      "allowed": false,
+      "transferInstruments": [
+        {
+          "enabled": true,
+          "requested": true,
+          "allowed": false,
+          "id": "SE322KH223222F5GXZFNM3BGP",
+          "verificationStatus": "pending"
+        }
+      ],
+      "verificationStatus": "pending"
+    }
+  },
+  "id": "AH3227C223222C5GXQXF658WB",
+  "status": "active"
+}

--- a/tests/Unit/AccountHolderTest.php
+++ b/tests/Unit/AccountHolderTest.php
@@ -67,6 +67,7 @@ class AccountHolderTest extends TestCaseMock
         );
     }
 
+
     /**
      * @return array
      */

--- a/tests/Unit/BalancePlatformTest.php
+++ b/tests/Unit/BalancePlatformTest.php
@@ -20,6 +20,61 @@ use function PHPUnit\Framework\assertEquals;
 
 class BalancePlatformTest extends TestCaseMock
 {
+
+    public function testGetAccountHolder()
+    {
+        $client = $this->createMockClientUrl(
+            'tests/Resources/BalancePlatform/get-account-holder.json'
+        );
+
+        $service = new AccountHoldersApi($client);
+        $response = $service->getAccountHolder('AH00AH3227C223222C5GXQXF658WB00000001');
+        self::assertEquals('AH3227C223222C5GXQXF658WB', $response->getId());
+        self::assertEquals(AccountHolder::STATUS_ACTIVE, $response->getStatus());
+        self::assertEquals("pending", $response['capabilities']['receiveFromPlatformPayments']['verificationStatus']);
+    }
+
+    public function testGetAccountHolderAdditionalAttributesDoesNotThrow()
+    {
+    
+        $client = $this->createMockClientUrl(
+        'tests/Resources/BalancePlatform/get-account-holder-additional-attributes.json'
+        );
+
+        $service = new AccountHoldersApi($client);
+
+        try {
+            $response = $service->getAccountHolder('AH00AH3227C223222C5GXQXF658WB00000001');
+
+            self::assertEquals('AH3227C223222C5GXQXF658WB', $response->getId());
+            self::assertEquals(AccountHolder::STATUS_ACTIVE, $response->getStatus());
+            self::assertEquals("pending", $response['capabilities']['receiveFromPlatformPayments']['verificationStatus']);
+        } catch (\Throwable $e) {
+            $this->fail('An unexpected exception was thrown: ' . $e->getMessage());
+        }
+    }
+
+    public function testGetAccountHolderUnknownEnum()
+    {
+        $this->markTestSkipped('This test should be enable when enum parsing is fixed.');
+
+        $client = $this->createMockClientUrl(
+            'tests/Resources/BalancePlatform/get-account-holder-unknown-enum.json'
+        );
+
+        $service = new AccountHoldersApi($client);
+
+        try {
+            $response = $service->getAccountHolder('AH00AH3227C223222C5GXQXF658WB00000001');
+
+            self::assertEquals('AH3227C223222C5GXQXF658WB', $response->getId());
+            self::assertEquals(AccountHolder::STATUS_ACTIVE, $response->getStatus());
+            self::assertEquals("pending", $response['capabilities']['receiveFromPlatformPayments']['verificationStatus']);
+        } catch (\Throwable $e) {
+            $this->fail('An unexpected exception was thrown: ' . $e->getMessage());
+        }
+    }
+
     /**
      * @throws AdyenException
      */

--- a/tests/Unit/BalancePlatformTest.php
+++ b/tests/Unit/BalancePlatformTest.php
@@ -38,7 +38,7 @@ class BalancePlatformTest extends TestCaseMock
     {
     
         $client = $this->createMockClientUrl(
-        'tests/Resources/BalancePlatform/get-account-holder-additional-attributes.json'
+            'tests/Resources/BalancePlatform/get-account-holder-additional-attributes.json'
         );
 
         $service = new AccountHoldersApi($client);


### PR DESCRIPTION
Adding unit tests to verify:

- additional response attributes don't thrown an exception
- unknown response enums don't thrown an exception: this fails. Test is skipped until the enum parsing will be corrected
