### PR TITLE
Remove leading backslash

### DIFF
--- a/templates/model.mustache
+++ b/templates/model.mustache
@@ -8,7 +8,7 @@ namespace {{modelPackage}};
 {{^isEnum}}
 {{^parentSchema}}
 
-use \ArrayAccess;
+use ArrayAccess;
 {{/parentSchema}}
 {{/isEnum}}
 use {{modelPackage}}\ObjectSerializer;

--- a/templates/model.mustache
+++ b/templates/model.mustache
@@ -22,7 +22,7 @@ use {{modelPackage}}\ObjectSerializer;
 {{/description}}
  * @package  {{packageName}}
 {{^isEnum}}
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
 {{/isEnum}}
  */
 {{#isEnum}}{{>model_enum}}{{/isEnum}}{{^isEnum}}{{>model_generic}}{{/isEnum}}


### PR DESCRIPTION
Fix templates to remove leading backslash
```
use \ArrayAccess;
```
to
```
use ArrayAccess;
```