### PR TITLE
Handling unknown enum values

### DIFF
--- a/src/Adyen/Model/BalancePlatform/AULocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/AULocalAccountIdentification.php
@@ -386,11 +386,11 @@ class AULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AccountHolder.php
+++ b/src/Adyen/Model/BalancePlatform/AccountHolder.php
@@ -651,11 +651,11 @@ class AccountHolder implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AccountHolderCapability.php
+++ b/src/Adyen/Model/BalancePlatform/AccountHolderCapability.php
@@ -462,11 +462,11 @@ class AccountHolderCapability implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getAllowedLevelAllowableValues();
         if (!in_array($allowedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'allowedLevel', must be one of '%s'",
+                    "allowedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $allowedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -592,11 +592,11 @@ class AccountHolderCapability implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getRequestedLevelAllowableValues();
         if (!in_array($requestedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'requestedLevel', must be one of '%s'",
+                    "requestedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $requestedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -674,11 +674,11 @@ class AccountHolderCapability implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getVerificationStatusAllowableValues();
         if (!in_array($verificationStatus, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'verificationStatus', must be one of '%s'",
+                    "verificationStatus: unexpected enum value '%s' - Supported values are [%s]",
                     $verificationStatus,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AccountHolderUpdateRequest.php
+++ b/src/Adyen/Model/BalancePlatform/AccountHolderUpdateRequest.php
@@ -583,11 +583,11 @@ class AccountHolderUpdateRequest implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AccountSupportingEntityCapability.php
+++ b/src/Adyen/Model/BalancePlatform/AccountSupportingEntityCapability.php
@@ -441,11 +441,11 @@ class AccountSupportingEntityCapability implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getAllowedLevelAllowableValues();
         if (!in_array($allowedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'allowedLevel', must be one of '%s'",
+                    "allowedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $allowedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -547,11 +547,11 @@ class AccountSupportingEntityCapability implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getRequestedLevelAllowableValues();
         if (!in_array($requestedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'requestedLevel', must be one of '%s'",
+                    "requestedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $requestedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -581,11 +581,11 @@ class AccountSupportingEntityCapability implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getVerificationStatusAllowableValues();
         if (!in_array($verificationStatus, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'verificationStatus', must be one of '%s'",
+                    "verificationStatus: unexpected enum value '%s' - Supported values are [%s]",
                     $verificationStatus,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AdditionalBankIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/AdditionalBankIdentification.php
@@ -352,11 +352,11 @@ class AdditionalBankIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AdditionalBankIdentificationRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/AdditionalBankIdentificationRequirement.php
@@ -359,11 +359,11 @@ class AdditionalBankIdentificationRequirement implements ModelInterface, ArrayAc
     {
         $allowedValues = $this->getAdditionalBankIdentificationTypeAllowableValues();
         if (!in_array($additionalBankIdentificationType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'additionalBankIdentificationType', must be one of '%s'",
+                    "additionalBankIdentificationType: unexpected enum value '%s' - Supported values are [%s]",
                     $additionalBankIdentificationType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -417,11 +417,11 @@ class AdditionalBankIdentificationRequirement implements ModelInterface, ArrayAc
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AddressRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/AddressRequirement.php
@@ -409,11 +409,11 @@ class AddressRequirement implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AmountMinMaxRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/AmountMinMaxRequirement.php
@@ -411,11 +411,11 @@ class AmountMinMaxRequirement implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AmountNonZeroDecimalsRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/AmountNonZeroDecimalsRequirement.php
@@ -349,11 +349,11 @@ class AmountNonZeroDecimalsRequirement implements ModelInterface, ArrayAccess, \
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AssociationFinaliseRequest.php
+++ b/src/Adyen/Model/BalancePlatform/AssociationFinaliseRequest.php
@@ -386,11 +386,11 @@ class AssociationFinaliseRequest implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AssociationFinaliseResponse.php
+++ b/src/Adyen/Model/BalancePlatform/AssociationFinaliseResponse.php
@@ -380,11 +380,11 @@ class AssociationFinaliseResponse implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/AssociationInitiateRequest.php
+++ b/src/Adyen/Model/BalancePlatform/AssociationInitiateRequest.php
@@ -352,11 +352,11 @@ class AssociationInitiateRequest implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BRLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/BRLocalAccountIdentification.php
@@ -451,11 +451,11 @@ class BRLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BalanceAccount.php
+++ b/src/Adyen/Model/BalancePlatform/BalanceAccount.php
@@ -613,11 +613,11 @@ class BalanceAccount implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BalanceAccountBase.php
+++ b/src/Adyen/Model/BalancePlatform/BalanceAccountBase.php
@@ -582,11 +582,11 @@ class BalanceAccountBase implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BalanceAccountUpdateRequest.php
+++ b/src/Adyen/Model/BalancePlatform/BalanceAccountUpdateRequest.php
@@ -483,11 +483,11 @@ class BalanceAccountUpdateRequest implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BankAccountIdentificationTypeRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/BankAccountIdentificationTypeRequirement.php
@@ -433,11 +433,11 @@ class BankAccountIdentificationTypeRequirement implements ModelInterface, ArrayA
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BankAccountModel.php
+++ b/src/Adyen/Model/BalancePlatform/BankAccountModel.php
@@ -329,11 +329,11 @@ class BankAccountModel implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         $allowedValues = $this->getFormFactorAllowableValues();
         if (!is_null($formFactor) && !in_array($formFactor, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'formFactor', must be one of '%s'",
+                    "formFactor: unexpected enum value '%s' - Supported values are [%s]",
                     $formFactor,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/BankIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/BankIdentification.php
@@ -383,11 +383,11 @@ class BankIdentification implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getIdentificationTypeAllowableValues();
         if (!in_array($identificationType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'identificationType', must be one of '%s'",
+                    "identificationType: unexpected enum value '%s' - Supported values are [%s]",
                     $identificationType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CALocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/CALocalAccountIdentification.php
@@ -402,11 +402,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -484,11 +484,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CZLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/CZLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class CZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CapabilityProblemEntity.php
+++ b/src/Adyen/Model/BalancePlatform/CapabilityProblemEntity.php
@@ -412,11 +412,11 @@ class CapabilityProblemEntity implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CapabilityProblemEntityRecursive.php
+++ b/src/Adyen/Model/BalancePlatform/CapabilityProblemEntityRecursive.php
@@ -381,11 +381,11 @@ class CapabilityProblemEntityRecursive implements ModelInterface, ArrayAccess, \
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CapabilitySettings.php
+++ b/src/Adyen/Model/BalancePlatform/CapabilitySettings.php
@@ -444,11 +444,11 @@ class CapabilitySettings implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getIntervalAllowableValues();
         if (!in_array($interval, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'interval', must be one of '%s'",
+                    "interval: unexpected enum value '%s' - Supported values are [%s]",
                     $interval,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/Card.php
+++ b/src/Adyen/Model/BalancePlatform/Card.php
@@ -641,11 +641,11 @@ class Card implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFormFactorAllowableValues();
         if (!in_array($formFactor, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'formFactor', must be one of '%s'",
+                    "formFactor: unexpected enum value '%s' - Supported values are [%s]",
                     $formFactor,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CardInfo.php
+++ b/src/Adyen/Model/BalancePlatform/CardInfo.php
@@ -531,11 +531,11 @@ class CardInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFormFactorAllowableValues();
         if (!in_array($formFactor, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'formFactor', must be one of '%s'",
+                    "formFactor: unexpected enum value '%s' - Supported values are [%s]",
                     $formFactor,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CardOrder.php
+++ b/src/Adyen/Model/BalancePlatform/CardOrder.php
@@ -534,11 +534,11 @@ class CardOrder implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CardOrderItemDeliveryStatus.php
+++ b/src/Adyen/Model/BalancePlatform/CardOrderItemDeliveryStatus.php
@@ -367,11 +367,11 @@ class CardOrderItemDeliveryStatus implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/CreateSweepConfigurationV2.php
+++ b/src/Adyen/Model/BalancePlatform/CreateSweepConfigurationV2.php
@@ -563,11 +563,11 @@ class CreateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -702,11 +702,11 @@ class CreateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -832,11 +832,11 @@ class CreateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -938,11 +938,11 @@ class CreateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/DKLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/DKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class DKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/Device.php
+++ b/src/Adyen/Model/BalancePlatform/Device.php
@@ -412,11 +412,11 @@ class Device implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/Duration.php
+++ b/src/Adyen/Model/BalancePlatform/Duration.php
@@ -330,11 +330,11 @@ class Duration implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getUnitAllowableValues();
         if (!in_array($unit, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'unit', must be one of '%s'",
+                    "unit: unexpected enum value '%s' - Supported values are [%s]",
                     $unit,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/GetTaxFormResponse.php
+++ b/src/Adyen/Model/BalancePlatform/GetTaxFormResponse.php
@@ -349,11 +349,11 @@ class GetTaxFormResponse implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getContentTypeAllowableValues();
         if (!in_array($contentType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'contentType', must be one of '%s'",
+                    "contentType: unexpected enum value '%s' - Supported values are [%s]",
                     $contentType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/GrantOffer.php
+++ b/src/Adyen/Model/BalancePlatform/GrantOffer.php
@@ -417,11 +417,11 @@ class GrantOffer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getContractTypeAllowableValues();
         if (!in_array($contractType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'contractType', must be one of '%s'",
+                    "contractType: unexpected enum value '%s' - Supported values are [%s]",
                     $contractType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/HKLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/HKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class HKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/HULocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/HULocalAccountIdentification.php
@@ -352,11 +352,11 @@ class HULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/IbanAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/IbanAccountIdentification.php
@@ -352,11 +352,11 @@ class IbanAccountIdentification implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/IbanAccountIdentificationRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/IbanAccountIdentificationRequirement.php
@@ -380,11 +380,11 @@ class IbanAccountIdentificationRequirement implements ModelInterface, ArrayAcces
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/NOLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/NOLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NOLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/NZLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/NZLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/NetworkToken.php
+++ b/src/Adyen/Model/BalancePlatform/NetworkToken.php
@@ -497,11 +497,11 @@ class NetworkToken implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/NumberAndBicAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/NumberAndBicAccountIdentification.php
@@ -417,11 +417,11 @@ class NumberAndBicAccountIdentification implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PLLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/PLLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class PLLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PaymentInstrument.php
+++ b/src/Adyen/Model/BalancePlatform/PaymentInstrument.php
@@ -757,11 +757,11 @@ class PaymentInstrument implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -815,11 +815,11 @@ class PaymentInstrument implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getStatusReasonAllowableValues();
         if (!in_array($statusReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'statusReason', must be one of '%s'",
+                    "statusReason: unexpected enum value '%s' - Supported values are [%s]",
                     $statusReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -849,11 +849,11 @@ class PaymentInstrument implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PaymentInstrumentInfo.php
+++ b/src/Adyen/Model/BalancePlatform/PaymentInstrumentInfo.php
@@ -628,11 +628,11 @@ class PaymentInstrumentInfo implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -686,11 +686,11 @@ class PaymentInstrumentInfo implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStatusReasonAllowableValues();
         if (!in_array($statusReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'statusReason', must be one of '%s'",
+                    "statusReason: unexpected enum value '%s' - Supported values are [%s]",
                     $statusReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -720,11 +720,11 @@ class PaymentInstrumentInfo implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PaymentInstrumentRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/PaymentInstrumentRequirement.php
@@ -472,11 +472,11 @@ class PaymentInstrumentRequirement implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getPaymentInstrumentTypeAllowableValues();
         if (!in_array($paymentInstrumentType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'paymentInstrumentType', must be one of '%s'",
+                    "paymentInstrumentType: unexpected enum value '%s' - Supported values are [%s]",
                     $paymentInstrumentType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -506,11 +506,11 @@ class PaymentInstrumentRequirement implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PaymentInstrumentUpdateRequest.php
+++ b/src/Adyen/Model/BalancePlatform/PaymentInstrumentUpdateRequest.php
@@ -434,11 +434,11 @@ class PaymentInstrumentUpdateRequest implements ModelInterface, ArrayAccess, \Js
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -492,11 +492,11 @@ class PaymentInstrumentUpdateRequest implements ModelInterface, ArrayAccess, \Js
     {
         $allowedValues = $this->getStatusReasonAllowableValues();
         if (!in_array($statusReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'statusReason', must be one of '%s'",
+                    "statusReason: unexpected enum value '%s' - Supported values are [%s]",
                     $statusReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/Phone.php
+++ b/src/Adyen/Model/BalancePlatform/Phone.php
@@ -354,11 +354,11 @@ class Phone implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PhoneNumber.php
+++ b/src/Adyen/Model/BalancePlatform/PhoneNumber.php
@@ -383,11 +383,11 @@ class PhoneNumber implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPhoneTypeAllowableValues();
         if (!in_array($phoneType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'phoneType', must be one of '%s'",
+                    "phoneType: unexpected enum value '%s' - Supported values are [%s]",
                     $phoneType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/PinChangeResponse.php
+++ b/src/Adyen/Model/BalancePlatform/PinChangeResponse.php
@@ -322,11 +322,11 @@ class PinChangeResponse implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/SELocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/SELocalAccountIdentification.php
@@ -386,11 +386,11 @@ class SELocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/SGLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/SGLocalAccountIdentification.php
@@ -383,11 +383,11 @@ class SGLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/StringMatch.php
+++ b/src/Adyen/Model/BalancePlatform/StringMatch.php
@@ -328,11 +328,11 @@ class StringMatch implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getOperationAllowableValues();
         if (!in_array($operation, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'operation', must be one of '%s'",
+                    "operation: unexpected enum value '%s' - Supported values are [%s]",
                     $operation,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/SweepConfigurationV2.php
+++ b/src/Adyen/Model/BalancePlatform/SweepConfigurationV2.php
@@ -573,11 +573,11 @@ class SweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -736,11 +736,11 @@ class SweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -866,11 +866,11 @@ class SweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -972,11 +972,11 @@ class SweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/SweepSchedule.php
+++ b/src/Adyen/Model/BalancePlatform/SweepSchedule.php
@@ -357,11 +357,11 @@ class SweepSchedule implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/TransactionRule.php
+++ b/src/Adyen/Model/BalancePlatform/TransactionRule.php
@@ -651,11 +651,11 @@ class TransactionRule implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getOutcomeTypeAllowableValues();
         if (!in_array($outcomeType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'outcomeType', must be one of '%s'",
+                    "outcomeType: unexpected enum value '%s' - Supported values are [%s]",
                     $outcomeType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -709,11 +709,11 @@ class TransactionRule implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getRequestTypeAllowableValues();
         if (!in_array($requestType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'requestType', must be one of '%s'",
+                    "requestType: unexpected enum value '%s' - Supported values are [%s]",
                     $requestType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -815,11 +815,11 @@ class TransactionRule implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -849,11 +849,11 @@ class TransactionRule implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/TransactionRuleInfo.php
+++ b/src/Adyen/Model/BalancePlatform/TransactionRuleInfo.php
@@ -620,11 +620,11 @@ class TransactionRuleInfo implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getOutcomeTypeAllowableValues();
         if (!in_array($outcomeType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'outcomeType', must be one of '%s'",
+                    "outcomeType: unexpected enum value '%s' - Supported values are [%s]",
                     $outcomeType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -678,11 +678,11 @@ class TransactionRuleInfo implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getRequestTypeAllowableValues();
         if (!in_array($requestType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'requestType', must be one of '%s'",
+                    "requestType: unexpected enum value '%s' - Supported values are [%s]",
                     $requestType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -784,11 +784,11 @@ class TransactionRuleInfo implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -818,11 +818,11 @@ class TransactionRuleInfo implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/TransactionRuleInterval.php
+++ b/src/Adyen/Model/BalancePlatform/TransactionRuleInterval.php
@@ -422,11 +422,11 @@ class TransactionRuleInterval implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getDayOfWeekAllowableValues();
         if (!in_array($dayOfWeek, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'dayOfWeek', must be one of '%s'",
+                    "dayOfWeek: unexpected enum value '%s' - Supported values are [%s]",
                     $dayOfWeek,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -528,11 +528,11 @@ class TransactionRuleInterval implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/TransferRoute.php
+++ b/src/Adyen/Model/BalancePlatform/TransferRoute.php
@@ -392,11 +392,11 @@ class TransferRoute implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -474,11 +474,11 @@ class TransferRoute implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPriorityAllowableValues();
         if (!in_array($priority, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'priority', must be one of '%s'",
+                    "priority: unexpected enum value '%s' - Supported values are [%s]",
                     $priority,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/TransferRouteRequest.php
+++ b/src/Adyen/Model/BalancePlatform/TransferRouteRequest.php
@@ -436,11 +436,11 @@ class TransferRouteRequest implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/UKLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/UKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class UKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/USInstantPayoutAddressRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/USInstantPayoutAddressRequirement.php
@@ -349,11 +349,11 @@ class USInstantPayoutAddressRequirement implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/USInternationalAchAddressRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/USInternationalAchAddressRequirement.php
@@ -349,11 +349,11 @@ class USInternationalAchAddressRequirement implements ModelInterface, ArrayAcces
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/USInternationalAchPriorityRequirement.php
+++ b/src/Adyen/Model/BalancePlatform/USInternationalAchPriorityRequirement.php
@@ -349,11 +349,11 @@ class USInternationalAchPriorityRequirement implements ModelInterface, ArrayAcce
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/USLocalAccountIdentification.php
+++ b/src/Adyen/Model/BalancePlatform/USLocalAccountIdentification.php
@@ -392,11 +392,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -450,11 +450,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/UpdateNetworkTokenRequest.php
+++ b/src/Adyen/Model/BalancePlatform/UpdateNetworkTokenRequest.php
@@ -319,11 +319,11 @@ class UpdateNetworkTokenRequest implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/UpdatePaymentInstrument.php
+++ b/src/Adyen/Model/BalancePlatform/UpdatePaymentInstrument.php
@@ -757,11 +757,11 @@ class UpdatePaymentInstrument implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -815,11 +815,11 @@ class UpdatePaymentInstrument implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getStatusReasonAllowableValues();
         if (!in_array($statusReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'statusReason', must be one of '%s'",
+                    "statusReason: unexpected enum value '%s' - Supported values are [%s]",
                     $statusReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -849,11 +849,11 @@ class UpdatePaymentInstrument implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/UpdateSweepConfigurationV2.php
+++ b/src/Adyen/Model/BalancePlatform/UpdateSweepConfigurationV2.php
@@ -561,11 +561,11 @@ class UpdateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -724,11 +724,11 @@ class UpdateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -854,11 +854,11 @@ class UpdateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -960,11 +960,11 @@ class UpdateSweepConfigurationV2 implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/VerificationError.php
+++ b/src/Adyen/Model/BalancePlatform/VerificationError.php
@@ -603,11 +603,11 @@ class VerificationError implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/BalancePlatform/VerificationErrorRecursive.php
+++ b/src/Adyen/Model/BalancePlatform/VerificationErrorRecursive.php
@@ -548,11 +548,11 @@ class VerificationErrorRecursive implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AccountInfo.php
+++ b/src/Adyen/Model/Checkout/AccountInfo.php
@@ -586,11 +586,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountAgeIndicatorAllowableValues();
         if (!in_array($accountAgeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountAgeIndicator', must be one of '%s'",
+                    "accountAgeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $accountAgeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -644,11 +644,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountChangeIndicatorAllowableValues();
         if (!in_array($accountChangeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountChangeIndicator', must be one of '%s'",
+                    "accountChangeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $accountChangeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -702,11 +702,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -784,11 +784,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDeliveryAddressUsageIndicatorAllowableValues();
         if (!in_array($deliveryAddressUsageIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryAddressUsageIndicator', must be one of '%s'",
+                    "deliveryAddressUsageIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryAddressUsageIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -894,11 +894,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPasswordChangeIndicatorAllowableValues();
         if (!in_array($passwordChangeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'passwordChangeIndicator', must be one of '%s'",
+                    "passwordChangeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $passwordChangeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1000,11 +1000,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPaymentAccountIndicatorAllowableValues();
         if (!in_array($paymentAccountIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'paymentAccountIndicator', must be one of '%s'",
+                    "paymentAccountIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $paymentAccountIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AcctInfo.php
+++ b/src/Adyen/Model/Checkout/AcctInfo.php
@@ -586,11 +586,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccAgeIndAllowableValues();
         if (!in_array($chAccAgeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccAgeInd', must be one of '%s'",
+                    "chAccAgeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccAgeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -644,11 +644,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccChangeIndAllowableValues();
         if (!in_array($chAccChangeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccChangeInd', must be one of '%s'",
+                    "chAccChangeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccChangeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -702,11 +702,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccPwChangeIndAllowableValues();
         if (!in_array($chAccPwChangeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccPwChangeInd', must be one of '%s'",
+                    "chAccPwChangeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccPwChangeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -808,11 +808,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPaymentAccIndAllowableValues();
         if (!in_array($paymentAccInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'paymentAccInd', must be one of '%s'",
+                    "paymentAccInd: unexpected enum value '%s' - Supported values are [%s]",
                     $paymentAccInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -890,11 +890,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShipAddressUsageIndAllowableValues();
         if (!in_array($shipAddressUsageInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shipAddressUsageInd', must be one of '%s'",
+                    "shipAddressUsageInd: unexpected enum value '%s' - Supported values are [%s]",
                     $shipAddressUsageInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -924,11 +924,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShipNameIndicatorAllowableValues();
         if (!in_array($shipNameIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shipNameIndicator', must be one of '%s'",
+                    "shipNameIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $shipNameIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -958,11 +958,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getSuspiciousAccActivityAllowableValues();
         if (!in_array($suspiciousAccActivity, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'suspiciousAccActivity', must be one of '%s'",
+                    "suspiciousAccActivity: unexpected enum value '%s' - Supported values are [%s]",
                     $suspiciousAccActivity,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AchDetails.php
+++ b/src/Adyen/Model/Checkout/AchDetails.php
@@ -450,11 +450,11 @@ class AchDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountHolderTypeAllowableValues();
         if (!in_array($accountHolderType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountHolderType', must be one of '%s'",
+                    "accountHolderType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountHolderType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -508,11 +508,11 @@ class AchDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getBankAccountTypeAllowableValues();
         if (!in_array($bankAccountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'bankAccountType', must be one of '%s'",
+                    "bankAccountType: unexpected enum value '%s' - Supported values are [%s]",
                     $bankAccountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -736,11 +736,11 @@ class AchDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AdditionalData3DSecure.php
+++ b/src/Adyen/Model/Checkout/AdditionalData3DSecure.php
@@ -384,11 +384,11 @@ class AdditionalData3DSecure implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getChallengeWindowSizeAllowableValues();
         if (!in_array($challengeWindowSize, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeWindowSize', must be one of '%s'",
+                    "challengeWindowSize: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeWindowSize,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AdditionalDataCommon.php
+++ b/src/Adyen/Model/Checkout/AdditionalDataCommon.php
@@ -601,11 +601,11 @@ class AdditionalDataCommon implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getIndustryUsageAllowableValues();
         if (!in_array($industryUsage, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'industryUsage', must be one of '%s'",
+                    "industryUsage: unexpected enum value '%s' - Supported values are [%s]",
                     $industryUsage,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AffirmDetails.php
+++ b/src/Adyen/Model/Checkout/AffirmDetails.php
@@ -346,11 +346,11 @@ class AffirmDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AfterpayDetails.php
+++ b/src/Adyen/Model/Checkout/AfterpayDetails.php
@@ -512,11 +512,11 @@ class AfterpayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AmazonPayDetails.php
+++ b/src/Adyen/Model/Checkout/AmazonPayDetails.php
@@ -408,11 +408,11 @@ class AmazonPayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AncvDetails.php
+++ b/src/Adyen/Model/Checkout/AncvDetails.php
@@ -441,11 +441,11 @@ class AncvDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AndroidPayDetails.php
+++ b/src/Adyen/Model/Checkout/AndroidPayDetails.php
@@ -346,11 +346,11 @@ class AndroidPayDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ApplePayDetails.php
+++ b/src/Adyen/Model/Checkout/ApplePayDetails.php
@@ -424,11 +424,11 @@ class ApplePayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -508,11 +508,11 @@ class ApplePayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ApplePayDonations.php
+++ b/src/Adyen/Model/Checkout/ApplePayDonations.php
@@ -424,11 +424,11 @@ class ApplePayDonations implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -508,11 +508,11 @@ class ApplePayDonations implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/AuthenticationData.php
+++ b/src/Adyen/Model/Checkout/AuthenticationData.php
@@ -331,11 +331,11 @@ class AuthenticationData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getAttemptAuthenticationAllowableValues();
         if (!in_array($attemptAuthentication, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'attemptAuthentication', must be one of '%s'",
+                    "attemptAuthentication: unexpected enum value '%s' - Supported values are [%s]",
                     $attemptAuthentication,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/BacsDirectDebitDetails.php
+++ b/src/Adyen/Model/Checkout/BacsDirectDebitDetails.php
@@ -534,11 +534,11 @@ class BacsDirectDebitDetails implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/BalanceCheckRequest.php
+++ b/src/Adyen/Model/Checkout/BalanceCheckRequest.php
@@ -1232,11 +1232,11 @@ class BalanceCheckRequest implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1410,11 +1410,11 @@ class BalanceCheckRequest implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/BalanceCheckResponse.php
+++ b/src/Adyen/Model/Checkout/BalanceCheckResponse.php
@@ -487,11 +487,11 @@ class BalanceCheckResponse implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/BillDeskDetails.php
+++ b/src/Adyen/Model/Checkout/BillDeskDetails.php
@@ -385,11 +385,11 @@ class BillDeskDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/BlikDetails.php
+++ b/src/Adyen/Model/Checkout/BlikDetails.php
@@ -441,11 +441,11 @@ class BlikDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CancelOrderResponse.php
+++ b/src/Adyen/Model/Checkout/CancelOrderResponse.php
@@ -352,11 +352,11 @@ class CancelOrderResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CardDetails.php
+++ b/src/Adyen/Model/Checkout/CardDetails.php
@@ -806,11 +806,11 @@ class CardDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1106,11 +1106,11 @@ class CardDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CardDonations.php
+++ b/src/Adyen/Model/Checkout/CardDonations.php
@@ -806,11 +806,11 @@ class CardDonations implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1106,11 +1106,11 @@ class CardDonations implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CashAppDetails.php
+++ b/src/Adyen/Model/Checkout/CashAppDetails.php
@@ -596,11 +596,11 @@ class CashAppDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CellulantDetails.php
+++ b/src/Adyen/Model/Checkout/CellulantDetails.php
@@ -377,11 +377,11 @@ class CellulantDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutAwaitAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutAwaitAction.php
@@ -387,11 +387,11 @@ class CheckoutAwaitAction implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutBankAccount.php
+++ b/src/Adyen/Model/Checkout/CheckoutBankAccount.php
@@ -390,11 +390,11 @@ class CheckoutBankAccount implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutBankTransferAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutBankTransferAction.php
@@ -666,11 +666,11 @@ class CheckoutBankTransferAction implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutDelegatedAuthenticationAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutDelegatedAuthenticationAction.php
@@ -449,11 +449,11 @@ class CheckoutDelegatedAuthenticationAction implements ModelInterface, ArrayAcce
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutNativeRedirectAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutNativeRedirectAction.php
@@ -449,11 +449,11 @@ class CheckoutNativeRedirectAction implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/CheckoutPaymentMethod.php
@@ -2070,7 +2070,7 @@ class CheckoutPaymentMethod implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Sets shopperEmail
      *
-     * @param string $shopperEmail
+     * @param string $shopperEmail 
      *
      * @return self
      */
@@ -2094,7 +2094,7 @@ class CheckoutPaymentMethod implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber
+     * @param string $telephoneNumber 
      *
      * @return self
      */

--- a/src/Adyen/Model/Checkout/CheckoutPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/CheckoutPaymentMethod.php
@@ -2070,7 +2070,7 @@ class CheckoutPaymentMethod implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Sets shopperEmail
      *
-     * @param string $shopperEmail 
+     * @param string $shopperEmail
      *
      * @return self
      */
@@ -2094,7 +2094,7 @@ class CheckoutPaymentMethod implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber 
+     * @param string $telephoneNumber
      *
      * @return self
      */

--- a/src/Adyen/Model/Checkout/CheckoutQrCodeAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutQrCodeAction.php
@@ -449,11 +449,11 @@ class CheckoutQrCodeAction implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutRedirectAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutRedirectAction.php
@@ -418,11 +418,11 @@ class CheckoutRedirectAction implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutSDKAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutSDKAction.php
@@ -420,11 +420,11 @@ class CheckoutSDKAction implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutSessionThreeDS2RequestData.php
+++ b/src/Adyen/Model/Checkout/CheckoutSessionThreeDS2RequestData.php
@@ -394,11 +394,11 @@ class CheckoutSessionThreeDS2RequestData implements ModelInterface, ArrayAccess,
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutThreeDS2Action.php
+++ b/src/Adyen/Model/Checkout/CheckoutThreeDS2Action.php
@@ -480,11 +480,11 @@ class CheckoutThreeDS2Action implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CheckoutVoucherAction.php
+++ b/src/Adyen/Model/Checkout/CheckoutVoucherAction.php
@@ -914,11 +914,11 @@ class CheckoutVoucherAction implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CreateCheckoutSessionRequest.php
+++ b/src/Adyen/Model/Checkout/CreateCheckoutSessionRequest.php
@@ -1116,11 +1116,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getChannelAllowableValues();
         if (!in_array($channel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'channel', must be one of '%s'",
+                    "channel: unexpected enum value '%s' - Supported values are [%s]",
                     $channel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1430,7 +1430,7 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, Riverty, and Zip.
      *
      * @return self
      */
@@ -1582,11 +1582,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getModeAllowableValues();
         if (!in_array($mode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'mode', must be one of '%s'",
+                    "mode: unexpected enum value '%s' - Supported values are [%s]",
                     $mode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1712,11 +1712,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1914,11 +1914,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2188,11 +2188,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getStoreFiltrationModeAllowableValues();
         if (!in_array($storeFiltrationMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storeFiltrationMode', must be one of '%s'",
+                    "storeFiltrationMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storeFiltrationMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2246,11 +2246,11 @@ class CreateCheckoutSessionRequest implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getStorePaymentMethodModeAllowableValues();
         if (!in_array($storePaymentMethodMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storePaymentMethodMode', must be one of '%s'",
+                    "storePaymentMethodMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storePaymentMethodMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CreateCheckoutSessionResponse.php
+++ b/src/Adyen/Model/Checkout/CreateCheckoutSessionResponse.php
@@ -1143,11 +1143,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getChannelAllowableValues();
         if (!in_array($channel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'channel', must be one of '%s'",
+                    "channel: unexpected enum value '%s' - Supported values are [%s]",
                     $channel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1481,7 +1481,7 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, Riverty, and Zip.
      *
      * @return self
      */
@@ -1633,11 +1633,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getModeAllowableValues();
         if (!in_array($mode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'mode', must be one of '%s'",
+                    "mode: unexpected enum value '%s' - Supported values are [%s]",
                     $mode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1763,11 +1763,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1989,11 +1989,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2263,11 +2263,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getStoreFiltrationModeAllowableValues();
         if (!in_array($storeFiltrationMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storeFiltrationMode', must be one of '%s'",
+                    "storeFiltrationMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storeFiltrationMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2321,11 +2321,11 @@ class CreateCheckoutSessionResponse implements ModelInterface, ArrayAccess, \Jso
     {
         $allowedValues = $this->getStorePaymentMethodModeAllowableValues();
         if (!in_array($storePaymentMethodMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storePaymentMethodMode', must be one of '%s'",
+                    "storePaymentMethodMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storePaymentMethodMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/CreateOrderResponse.php
+++ b/src/Adyen/Model/Checkout/CreateOrderResponse.php
@@ -609,11 +609,11 @@ class CreateOrderResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DeliveryMethod.php
+++ b/src/Adyen/Model/Checkout/DeliveryMethod.php
@@ -439,11 +439,11 @@ class DeliveryMethod implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DeviceRenderOptions.php
+++ b/src/Adyen/Model/Checkout/DeviceRenderOptions.php
@@ -346,11 +346,11 @@ class DeviceRenderOptions implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getSdkInterfaceAllowableValues();
         if (!in_array($sdkInterface, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'sdkInterface', must be one of '%s'",
+                    "sdkInterface: unexpected enum value '%s' - Supported values are [%s]",
                     $sdkInterface,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DokuDetails.php
+++ b/src/Adyen/Model/Checkout/DokuDetails.php
@@ -471,11 +471,11 @@ class DokuDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DonationPaymentRequest.php
+++ b/src/Adyen/Model/Checkout/DonationPaymentRequest.php
@@ -841,11 +841,11 @@ class DonationPaymentRequest implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getChannelAllowableValues();
         if (!in_array($channel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'channel', must be one of '%s'",
+                    "channel: unexpected enum value '%s' - Supported values are [%s]",
                     $channel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1133,7 +1133,7 @@ class DonationPaymentRequest implements ModelInterface, ArrayAccess, \JsonSerial
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, Riverty, and Zip.
      *
      * @return self
      */
@@ -1309,11 +1309,11 @@ class DonationPaymentRequest implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1511,11 +1511,11 @@ class DonationPaymentRequest implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DonationPaymentResponse.php
+++ b/src/Adyen/Model/Checkout/DonationPaymentResponse.php
@@ -505,11 +505,11 @@ class DonationPaymentResponse implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/DragonpayDetails.php
+++ b/src/Adyen/Model/Checkout/DragonpayDetails.php
@@ -420,11 +420,11 @@ class DragonpayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/EBankingFinlandDetails.php
+++ b/src/Adyen/Model/Checkout/EBankingFinlandDetails.php
@@ -380,11 +380,11 @@ class EBankingFinlandDetails implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/EcontextVoucherDetails.php
+++ b/src/Adyen/Model/Checkout/EcontextVoucherDetails.php
@@ -493,11 +493,11 @@ class EcontextVoucherDetails implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/EftDetails.php
+++ b/src/Adyen/Model/Checkout/EftDetails.php
@@ -534,11 +534,11 @@ class EftDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/FastlaneDetails.php
+++ b/src/Adyen/Model/Checkout/FastlaneDetails.php
@@ -447,11 +447,11 @@ class FastlaneDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/FundRecipient.php
+++ b/src/Adyen/Model/Checkout/FundRecipient.php
@@ -664,11 +664,11 @@ class FundRecipient implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getWalletPurposeAllowableValues();
         if (!in_array($walletPurpose, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'walletPurpose', must be one of '%s'",
+                    "walletPurpose: unexpected enum value '%s' - Supported values are [%s]",
                     $walletPurpose,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/GenericIssuerPaymentMethodDetails.php
+++ b/src/Adyen/Model/Checkout/GenericIssuerPaymentMethodDetails.php
@@ -453,11 +453,11 @@ class GenericIssuerPaymentMethodDetails implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/GooglePayDetails.php
+++ b/src/Adyen/Model/Checkout/GooglePayDetails.php
@@ -414,11 +414,11 @@ class GooglePayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -570,11 +570,11 @@ class GooglePayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/GooglePayDonations.php
+++ b/src/Adyen/Model/Checkout/GooglePayDonations.php
@@ -414,11 +414,11 @@ class GooglePayDonations implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -570,11 +570,11 @@ class GooglePayDonations implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/IdealDetails.php
+++ b/src/Adyen/Model/Checkout/IdealDetails.php
@@ -441,11 +441,11 @@ class IdealDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/IdealDonations.php
+++ b/src/Adyen/Model/Checkout/IdealDonations.php
@@ -441,11 +441,11 @@ class IdealDonations implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Installments.php
+++ b/src/Adyen/Model/Checkout/Installments.php
@@ -374,11 +374,11 @@ class Installments implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPlanAllowableValues();
         if (!in_array($plan, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'plan', must be one of '%s'",
+                    "plan: unexpected enum value '%s' - Supported values are [%s]",
                     $plan,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/KlarnaDetails.php
+++ b/src/Adyen/Model/Checkout/KlarnaDetails.php
@@ -549,11 +549,11 @@ class KlarnaDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Mandate.php
+++ b/src/Adyen/Model/Checkout/Mandate.php
@@ -466,11 +466,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAmountRuleAllowableValues();
         if (!in_array($amountRule, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'amountRule', must be one of '%s'",
+                    "amountRule: unexpected enum value '%s' - Supported values are [%s]",
                     $amountRule,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -500,11 +500,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getBillingAttemptsRuleAllowableValues();
         if (!in_array($billingAttemptsRule, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'billingAttemptsRule', must be one of '%s'",
+                    "billingAttemptsRule: unexpected enum value '%s' - Supported values are [%s]",
                     $billingAttemptsRule,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -606,11 +606,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFrequencyAllowableValues();
         if (!in_array($frequency, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'frequency', must be one of '%s'",
+                    "frequency: unexpected enum value '%s' - Supported values are [%s]",
                     $frequency,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/MasterpassDetails.php
+++ b/src/Adyen/Model/Checkout/MasterpassDetails.php
@@ -386,11 +386,11 @@ class MasterpassDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -444,11 +444,11 @@ class MasterpassDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/MbwayDetails.php
+++ b/src/Adyen/Model/Checkout/MbwayDetails.php
@@ -358,7 +358,7 @@ class MbwayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets shopperEmail
      *
-     * @param string $shopperEmail
+     * @param string $shopperEmail 
      *
      * @return self
      */
@@ -382,7 +382,7 @@ class MbwayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber
+     * @param string $telephoneNumber 
      *
      * @return self
      */
@@ -414,11 +414,11 @@ class MbwayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/MbwayDetails.php
+++ b/src/Adyen/Model/Checkout/MbwayDetails.php
@@ -358,7 +358,7 @@ class MbwayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets shopperEmail
      *
-     * @param string $shopperEmail 
+     * @param string $shopperEmail
      *
      * @return self
      */
@@ -382,7 +382,7 @@ class MbwayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber 
+     * @param string $telephoneNumber
      *
      * @return self
      */

--- a/src/Adyen/Model/Checkout/MerchantRiskIndicator.php
+++ b/src/Adyen/Model/Checkout/MerchantRiskIndicator.php
@@ -469,11 +469,11 @@ class MerchantRiskIndicator implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getDeliveryAddressIndicatorAllowableValues();
         if (!in_array($deliveryAddressIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryAddressIndicator', must be one of '%s'",
+                    "deliveryAddressIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryAddressIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -553,11 +553,11 @@ class MerchantRiskIndicator implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getDeliveryTimeframeAllowableValues();
         if (!in_array($deliveryTimeframe, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryTimeframe', must be one of '%s'",
+                    "deliveryTimeframe: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryTimeframe,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/MobilePayDetails.php
+++ b/src/Adyen/Model/Checkout/MobilePayDetails.php
@@ -346,11 +346,11 @@ class MobilePayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/MolPayDetails.php
+++ b/src/Adyen/Model/Checkout/MolPayDetails.php
@@ -385,11 +385,11 @@ class MolPayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ObjectSerializer.php
+++ b/src/Adyen/Model/Checkout/ObjectSerializer.php
@@ -82,7 +82,7 @@ class ObjectSerializer
                     }
                 }
             } else {
-                foreach ($data as $property => $value) {
+                foreach($data as $property => $value) {
                     $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
@@ -118,9 +118,7 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) {
-            return $timestamp;
-        }
+        if (!is_string($timestamp)) return $timestamp;
 
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }

--- a/src/Adyen/Model/Checkout/ObjectSerializer.php
+++ b/src/Adyen/Model/Checkout/ObjectSerializer.php
@@ -82,7 +82,7 @@ class ObjectSerializer
                     }
                 }
             } else {
-                foreach($data as $property => $value) {
+                foreach ($data as $property => $value) {
                     $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
@@ -118,7 +118,9 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) return $timestamp;
+        if (!is_string($timestamp)) {
+            return $timestamp;
+        }
 
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }

--- a/src/Adyen/Model/Checkout/OpenInvoiceDetails.php
+++ b/src/Adyen/Model/Checkout/OpenInvoiceDetails.php
@@ -507,11 +507,11 @@ class OpenInvoiceDetails implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayByBankAISDirectDebitDetails.php
+++ b/src/Adyen/Model/Checkout/PayByBankAISDirectDebitDetails.php
@@ -413,11 +413,11 @@ class PayByBankAISDirectDebitDetails implements ModelInterface, ArrayAccess, \Js
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayByBankDetails.php
+++ b/src/Adyen/Model/Checkout/PayByBankDetails.php
@@ -380,11 +380,11 @@ class PayByBankDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayPalDetails.php
+++ b/src/Adyen/Model/Checkout/PayPalDetails.php
@@ -569,11 +569,11 @@ class PayPalDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getSubtypeAllowableValues();
         if (!in_array($subtype, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'subtype', must be one of '%s'",
+                    "subtype: unexpected enum value '%s' - Supported values are [%s]",
                     $subtype,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -603,11 +603,11 @@ class PayPalDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayPayDetails.php
+++ b/src/Adyen/Model/Checkout/PayPayDetails.php
@@ -410,11 +410,11 @@ class PayPayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayToDetails.php
+++ b/src/Adyen/Model/Checkout/PayToDetails.php
@@ -441,11 +441,11 @@ class PayToDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayToPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/PayToPaymentMethod.php
@@ -14,6 +14,7 @@
 
 
 namespace Adyen\Model\Checkout;
+
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**

--- a/src/Adyen/Model/Checkout/PayToPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/PayToPaymentMethod.php
@@ -14,7 +14,6 @@
 
 
 namespace Adyen\Model\Checkout;
-
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**

--- a/src/Adyen/Model/Checkout/PayUUpiDetails.php
+++ b/src/Adyen/Model/Checkout/PayUUpiDetails.php
@@ -451,11 +451,11 @@ class PayUUpiDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayWithGoogleDetails.php
+++ b/src/Adyen/Model/Checkout/PayWithGoogleDetails.php
@@ -407,11 +407,11 @@ class PayWithGoogleDetails implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -539,11 +539,11 @@ class PayWithGoogleDetails implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PayWithGoogleDonations.php
+++ b/src/Adyen/Model/Checkout/PayWithGoogleDonations.php
@@ -407,11 +407,11 @@ class PayWithGoogleDonations implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -539,11 +539,11 @@ class PayWithGoogleDonations implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Payment.php
+++ b/src/Adyen/Model/Checkout/Payment.php
@@ -408,11 +408,11 @@ class Payment implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentAmountUpdateRequest.php
+++ b/src/Adyen/Model/Checkout/PaymentAmountUpdateRequest.php
@@ -446,11 +446,11 @@ class PaymentAmountUpdateRequest implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getIndustryUsageAllowableValues();
         if (!in_array($industryUsage, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'industryUsage', must be one of '%s'",
+                    "industryUsage: unexpected enum value '%s' - Supported values are [%s]",
                     $industryUsage,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentAmountUpdateResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentAmountUpdateResponse.php
@@ -438,11 +438,11 @@ class PaymentAmountUpdateResponse implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getIndustryUsageAllowableValues();
         if (!in_array($industryUsage, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'industryUsage', must be one of '%s'",
+                    "industryUsage: unexpected enum value '%s' - Supported values are [%s]",
                     $industryUsage,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -616,11 +616,11 @@ class PaymentAmountUpdateResponse implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentCancelResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentCancelResponse.php
@@ -451,11 +451,11 @@ class PaymentCancelResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentCaptureResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentCaptureResponse.php
@@ -585,11 +585,11 @@ class PaymentCaptureResponse implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentDetails.php
+++ b/src/Adyen/Model/Checkout/PaymentDetails.php
@@ -522,11 +522,11 @@ class PaymentDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentDetailsResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentDetailsResponse.php
@@ -710,11 +710,11 @@ class PaymentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentLinkRequest.php
+++ b/src/Adyen/Model/Checkout/PaymentLinkRequest.php
@@ -1012,7 +1012,7 @@ class PaymentLinkRequest implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. This parameter is required for open invoice (_buy now, pay later_) payment methods such Afterpay, Clearpay, Klarna, RatePay, Riverty, and Zip.
      *
      * @return self
      */
@@ -1188,11 +1188,11 @@ class PaymentLinkRequest implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1591,11 +1591,11 @@ class PaymentLinkRequest implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getStorePaymentMethodModeAllowableValues();
         if (!in_array($storePaymentMethodMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storePaymentMethodMode', must be one of '%s'",
+                    "storePaymentMethodMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storePaymentMethodMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentLinkResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentLinkResponse.php
@@ -1102,7 +1102,7 @@ class PaymentLinkResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. This parameter is required for open invoice (_buy now, pay later_) payment methods such Afterpay, Clearpay, Klarna, RatePay, Riverty, and Zip.
      *
      * @return self
      */
@@ -1278,11 +1278,11 @@ class PaymentLinkResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1657,11 +1657,11 @@ class PaymentLinkResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1715,11 +1715,11 @@ class PaymentLinkResponse implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getStorePaymentMethodModeAllowableValues();
         if (!in_array($storePaymentMethodMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storePaymentMethodMode', must be one of '%s'",
+                    "storePaymentMethodMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storePaymentMethodMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentMethod.php
+++ b/src/Adyen/Model/Checkout/PaymentMethod.php
@@ -483,11 +483,11 @@ class PaymentMethod implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentMethodsRequest.php
+++ b/src/Adyen/Model/Checkout/PaymentMethodsRequest.php
@@ -586,11 +586,11 @@ class PaymentMethodsRequest implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getChannelAllowableValues();
         if (!in_array($channel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'channel', must be one of '%s'",
+                    "channel: unexpected enum value '%s' - Supported values are [%s]",
                     $channel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -860,11 +860,11 @@ class PaymentMethodsRequest implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStoreFiltrationModeAllowableValues();
         if (!in_array($storeFiltrationMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'storeFiltrationMode', must be one of '%s'",
+                    "storeFiltrationMode: unexpected enum value '%s' - Supported values are [%s]",
                     $storeFiltrationMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentRefundRequest.php
+++ b/src/Adyen/Model/Checkout/PaymentRefundRequest.php
@@ -546,11 +546,11 @@ class PaymentRefundRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         }
         $allowedValues = $this->getMerchantRefundReasonAllowableValues();
         if (!is_null($merchantRefundReason) && !in_array($merchantRefundReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'merchantRefundReason', must be one of '%s'",
+                    "merchantRefundReason: unexpected enum value '%s' - Supported values are [%s]",
                     $merchantRefundReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentRefundResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentRefundResponse.php
@@ -535,11 +535,11 @@ class PaymentRefundResponse implements ModelInterface, ArrayAccess, \JsonSeriali
         }
         $allowedValues = $this->getMerchantRefundReasonAllowableValues();
         if (!is_null($merchantRefundReason) && !in_array($merchantRefundReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'merchantRefundReason', must be one of '%s'",
+                    "merchantRefundReason: unexpected enum value '%s' - Supported values are [%s]",
                     $merchantRefundReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -665,11 +665,11 @@ class PaymentRefundResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentRequest.php
+++ b/src/Adyen/Model/Checkout/PaymentRequest.php
@@ -1171,11 +1171,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChannelAllowableValues();
         if (!in_array($channel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'channel', must be one of '%s'",
+                    "channel: unexpected enum value '%s' - Supported values are [%s]",
                     $channel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1545,11 +1545,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getEntityTypeAllowableValues();
         if (!in_array($entityType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'entityType', must be one of '%s'",
+                    "entityType: unexpected enum value '%s' - Supported values are [%s]",
                     $entityType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1651,11 +1651,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getIndustryUsageAllowableValues();
         if (!in_array($industryUsage, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'industryUsage', must be one of '%s'",
+                    "industryUsage: unexpected enum value '%s' - Supported values are [%s]",
                     $industryUsage,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1701,7 +1701,7 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets lineItems
      *
-     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, and Riverty.
+     * @param \Adyen\Model\Checkout\LineItem[]|null $lineItems Price and product information about the purchased items, to be included on the invoice sent to the shopper. > This field is required for 3x 4x Oney, Affirm, Afterpay, Clearpay, Klarna, Ratepay, Riverty, and Zip.
      *
      * @return self
      */
@@ -2093,11 +2093,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2343,11 +2343,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentResponse.php
@@ -703,11 +703,11 @@ class PaymentResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaymentReversalResponse.php
+++ b/src/Adyen/Model/Checkout/PaymentReversalResponse.php
@@ -451,11 +451,11 @@ class PaymentReversalResponse implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PaypalUpdateOrderResponse.php
+++ b/src/Adyen/Model/Checkout/PaypalUpdateOrderResponse.php
@@ -354,11 +354,11 @@ class PaypalUpdateOrderResponse implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PixDetails.php
+++ b/src/Adyen/Model/Checkout/PixDetails.php
@@ -441,11 +441,11 @@ class PixDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PixRecurring.php
+++ b/src/Adyen/Model/Checkout/PixRecurring.php
@@ -458,11 +458,11 @@ class PixRecurring implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFrequencyAllowableValues();
         if (!in_array($frequency, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'frequency', must be one of '%s'",
+                    "frequency: unexpected enum value '%s' - Supported values are [%s]",
                     $frequency,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PlatformChargebackLogic.php
+++ b/src/Adyen/Model/Checkout/PlatformChargebackLogic.php
@@ -333,11 +333,11 @@ class PlatformChargebackLogic implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getBehaviorAllowableValues();
         if (!in_array($behavior, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'behavior', must be one of '%s'",
+                    "behavior: unexpected enum value '%s' - Supported values are [%s]",
                     $behavior,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/PseDetails.php
+++ b/src/Adyen/Model/Checkout/PseDetails.php
@@ -482,11 +482,11 @@ class PseDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/RakutenPayDetails.php
+++ b/src/Adyen/Model/Checkout/RakutenPayDetails.php
@@ -410,11 +410,11 @@ class RakutenPayDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/RatepayDetails.php
+++ b/src/Adyen/Model/Checkout/RatepayDetails.php
@@ -508,11 +508,11 @@ class RatepayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Recurring.php
+++ b/src/Adyen/Model/Checkout/Recurring.php
@@ -374,11 +374,11 @@ class Recurring implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getContractAllowableValues();
         if (!in_array($contract, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'contract', must be one of '%s'",
+                    "contract: unexpected enum value '%s' - Supported values are [%s]",
                     $contract,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -480,11 +480,11 @@ class Recurring implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTokenServiceAllowableValues();
         if (!in_array($tokenService, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'tokenService', must be one of '%s'",
+                    "tokenService: unexpected enum value '%s' - Supported values are [%s]",
                     $tokenService,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ResponseAdditionalDataCard.php
+++ b/src/Adyen/Model/Checkout/ResponseAdditionalDataCard.php
@@ -535,11 +535,11 @@ class ResponseAdditionalDataCard implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getCardProductIdAllowableValues();
         if (!in_array($cardProductId, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'cardProductId', must be one of '%s'",
+                    "cardProductId: unexpected enum value '%s' - Supported values are [%s]",
                     $cardProductId,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ResponseAdditionalDataCommon.php
+++ b/src/Adyen/Model/Checkout/ResponseAdditionalDataCommon.php
@@ -1358,11 +1358,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getFraudResultTypeAllowableValues();
         if (!in_array($fraudResultType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fraudResultType', must be one of '%s'",
+                    "fraudResultType: unexpected enum value '%s' - Supported values are [%s]",
                     $fraudResultType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1392,11 +1392,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getFraudRiskLevelAllowableValues();
         if (!in_array($fraudRiskLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fraudRiskLevel', must be one of '%s'",
+                    "fraudRiskLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $fraudRiskLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1934,11 +1934,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2280,11 +2280,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTokenizationStoreOperationTypeAllowableValues();
         if (!in_array($tokenizationStoreOperationType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'tokenizationStoreOperationType', must be one of '%s'",
+                    "tokenizationStoreOperationType: unexpected enum value '%s' - Supported values are [%s]",
                     $tokenizationStoreOperationType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Result.php
+++ b/src/Adyen/Model/Checkout/Result.php
@@ -14,7 +14,6 @@
 
 
 namespace Adyen\Model\Checkout;
-
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**
@@ -46,3 +45,4 @@ class Result
         ];
     }
 }
+

--- a/src/Adyen/Model/Checkout/Result.php
+++ b/src/Adyen/Model/Checkout/Result.php
@@ -14,6 +14,7 @@
 
 
 namespace Adyen\Model\Checkout;
+
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**
@@ -45,4 +46,3 @@ class Result
         ];
     }
 }
-

--- a/src/Adyen/Model/Checkout/RivertyDetails.php
+++ b/src/Adyen/Model/Checkout/RivertyDetails.php
@@ -605,11 +605,11 @@ class RivertyDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/SamsungPayDetails.php
+++ b/src/Adyen/Model/Checkout/SamsungPayDetails.php
@@ -400,11 +400,11 @@ class SamsungPayDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -508,11 +508,11 @@ class SamsungPayDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/SepaDirectDebitDetails.php
+++ b/src/Adyen/Model/Checkout/SepaDirectDebitDetails.php
@@ -511,11 +511,11 @@ class SepaDirectDebitDetails implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/SessionResultResponse.php
+++ b/src/Adyen/Model/Checkout/SessionResultResponse.php
@@ -449,11 +449,11 @@ class SessionResultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/Split.php
+++ b/src/Adyen/Model/Checkout/Split.php
@@ -472,11 +472,11 @@ class Split implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/StandalonePaymentCancelResponse.php
+++ b/src/Adyen/Model/Checkout/StandalonePaymentCancelResponse.php
@@ -451,11 +451,11 @@ class StandalonePaymentCancelResponse implements ModelInterface, ArrayAccess, \J
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/StoredPaymentMethodDetails.php
+++ b/src/Adyen/Model/Checkout/StoredPaymentMethodDetails.php
@@ -444,11 +444,11 @@ class StoredPaymentMethodDetails implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/StoredPaymentMethodRequest.php
+++ b/src/Adyen/Model/Checkout/StoredPaymentMethodRequest.php
@@ -414,11 +414,11 @@ class StoredPaymentMethodRequest implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDS2RequestData.php
+++ b/src/Adyen/Model/Checkout/ThreeDS2RequestData.php
@@ -751,11 +751,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getAcctTypeAllowableValues();
         if (!in_array($acctType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'acctType', must be one of '%s'",
+                    "acctType: unexpected enum value '%s' - Supported values are [%s]",
                     $acctType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -833,11 +833,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getAddrMatchAllowableValues();
         if (!in_array($addrMatch, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'addrMatch', must be one of '%s'",
+                    "addrMatch: unexpected enum value '%s' - Supported values are [%s]",
                     $addrMatch,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -895,11 +895,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getChallengeIndicatorAllowableValues();
         if (!in_array($challengeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeIndicator', must be one of '%s'",
+                    "challengeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1481,11 +1481,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1611,11 +1611,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTransTypeAllowableValues();
         if (!in_array($transType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transType', must be one of '%s'",
+                    "transType: unexpected enum value '%s' - Supported values are [%s]",
                     $transType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1645,11 +1645,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTransactionTypeAllowableValues();
         if (!in_array($transactionType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transactionType', must be one of '%s'",
+                    "transactionType: unexpected enum value '%s' - Supported values are [%s]",
                     $transactionType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDS2RequestFields.php
+++ b/src/Adyen/Model/Checkout/ThreeDS2RequestFields.php
@@ -727,11 +727,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getAcctTypeAllowableValues();
         if (!in_array($acctType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'acctType', must be one of '%s'",
+                    "acctType: unexpected enum value '%s' - Supported values are [%s]",
                     $acctType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -809,11 +809,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getAddrMatchAllowableValues();
         if (!in_array($addrMatch, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'addrMatch', must be one of '%s'",
+                    "addrMatch: unexpected enum value '%s' - Supported values are [%s]",
                     $addrMatch,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -871,11 +871,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getChallengeIndicatorAllowableValues();
         if (!in_array($challengeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeIndicator', must be one of '%s'",
+                    "challengeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1385,11 +1385,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1515,11 +1515,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getTransTypeAllowableValues();
         if (!in_array($transType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transType', must be one of '%s'",
+                    "transType: unexpected enum value '%s' - Supported values are [%s]",
                     $transType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1549,11 +1549,11 @@ class ThreeDS2RequestFields implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getTransactionTypeAllowableValues();
         if (!in_array($transactionType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transactionType', must be one of '%s'",
+                    "transactionType: unexpected enum value '%s' - Supported values are [%s]",
                     $transactionType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDS2Result.php
+++ b/src/Adyen/Model/Checkout/ThreeDS2Result.php
@@ -524,11 +524,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChallengeCancelAllowableValues();
         if (!in_array($challengeCancel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeCancel', must be one of '%s'",
+                    "challengeCancel: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeCancel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -606,11 +606,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getExemptionIndicatorAllowableValues();
         if (!in_array($exemptionIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'exemptionIndicator', must be one of '%s'",
+                    "exemptionIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $exemptionIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -688,11 +688,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDSRequestData.php
+++ b/src/Adyen/Model/Checkout/ThreeDSRequestData.php
@@ -413,11 +413,11 @@ class ThreeDSRequestData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getChallengeWindowSizeAllowableValues();
         if (!in_array($challengeWindowSize, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeWindowSize', must be one of '%s'",
+                    "challengeWindowSize: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeWindowSize,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -447,11 +447,11 @@ class ThreeDSRequestData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getDataOnlyAllowableValues();
         if (!in_array($dataOnly, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'dataOnly', must be one of '%s'",
+                    "dataOnly: unexpected enum value '%s' - Supported values are [%s]",
                     $dataOnly,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -481,11 +481,11 @@ class ThreeDSRequestData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getNativeThreeDSAllowableValues();
         if (!in_array($nativeThreeDS, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'nativeThreeDS', must be one of '%s'",
+                    "nativeThreeDS: unexpected enum value '%s' - Supported values are [%s]",
                     $nativeThreeDS,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -515,11 +515,11 @@ class ThreeDSRequestData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getThreeDSVersionAllowableValues();
         if (!in_array($threeDSVersion, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSVersion', must be one of '%s'",
+                    "threeDSVersion: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSVersion,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDSRequestorAuthenticationInfo.php
+++ b/src/Adyen/Model/Checkout/ThreeDSRequestorAuthenticationInfo.php
@@ -363,11 +363,11 @@ class ThreeDSRequestorAuthenticationInfo implements ModelInterface, ArrayAccess,
     {
         $allowedValues = $this->getThreeDSReqAuthMethodAllowableValues();
         if (!in_array($threeDSReqAuthMethod, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSReqAuthMethod', must be one of '%s'",
+                    "threeDSReqAuthMethod: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSReqAuthMethod,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDSRequestorPriorAuthenticationInfo.php
+++ b/src/Adyen/Model/Checkout/ThreeDSRequestorPriorAuthenticationInfo.php
@@ -366,11 +366,11 @@ class ThreeDSRequestorPriorAuthenticationInfo implements ModelInterface, ArrayAc
     {
         $allowedValues = $this->getThreeDSReqPriorAuthMethodAllowableValues();
         if (!in_array($threeDSReqPriorAuthMethod, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSReqPriorAuthMethod', must be one of '%s'",
+                    "threeDSReqPriorAuthMethod: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSReqPriorAuthMethod,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ThreeDSecureData.php
+++ b/src/Adyen/Model/Checkout/ThreeDSecureData.php
@@ -466,11 +466,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAuthenticationResponseAllowableValues();
         if (!in_array($authenticationResponse, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'authenticationResponse', must be one of '%s'",
+                    "authenticationResponse: unexpected enum value '%s' - Supported values are [%s]",
                     $authenticationResponse,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -548,11 +548,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChallengeCancelAllowableValues();
         if (!in_array($challengeCancel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeCancel', must be one of '%s'",
+                    "challengeCancel: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeCancel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -582,11 +582,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDirectoryResponseAllowableValues();
         if (!in_array($directoryResponse, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'directoryResponse', must be one of '%s'",
+                    "directoryResponse: unexpected enum value '%s' - Supported values are [%s]",
                     $directoryResponse,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/TwintDetails.php
+++ b/src/Adyen/Model/Checkout/TwintDetails.php
@@ -441,11 +441,11 @@ class TwintDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/UPIPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/UPIPaymentMethod.php
@@ -14,6 +14,7 @@
 
 
 namespace Adyen\Model\Checkout;
+
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**

--- a/src/Adyen/Model/Checkout/UPIPaymentMethod.php
+++ b/src/Adyen/Model/Checkout/UPIPaymentMethod.php
@@ -14,7 +14,6 @@
 
 
 namespace Adyen\Model\Checkout;
-
 use Adyen\Model\Checkout\ObjectSerializer;
 
 /**

--- a/src/Adyen/Model/Checkout/UpdatePaymentLinkRequest.php
+++ b/src/Adyen/Model/Checkout/UpdatePaymentLinkRequest.php
@@ -318,11 +318,11 @@ class UpdatePaymentLinkRequest implements ModelInterface, ArrayAccess, \JsonSeri
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/UpiCollectDetails.php
+++ b/src/Adyen/Model/Checkout/UpiCollectDetails.php
@@ -485,11 +485,11 @@ class UpiCollectDetails implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/UpiIntentDetails.php
+++ b/src/Adyen/Model/Checkout/UpiIntentDetails.php
@@ -475,11 +475,11 @@ class UpiIntentDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/VippsDetails.php
+++ b/src/Adyen/Model/Checkout/VippsDetails.php
@@ -412,7 +412,7 @@ class VippsDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber 
+     * @param string $telephoneNumber
      *
      * @return self
      */

--- a/src/Adyen/Model/Checkout/VippsDetails.php
+++ b/src/Adyen/Model/Checkout/VippsDetails.php
@@ -412,7 +412,7 @@ class VippsDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets telephoneNumber
      *
-     * @param string $telephoneNumber
+     * @param string $telephoneNumber 
      *
      * @return self
      */
@@ -444,11 +444,11 @@ class VippsDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/VisaCheckoutDetails.php
+++ b/src/Adyen/Model/Checkout/VisaCheckoutDetails.php
@@ -386,11 +386,11 @@ class VisaCheckoutDetails implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -420,11 +420,11 @@ class VisaCheckoutDetails implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/WeChatPayDetails.php
+++ b/src/Adyen/Model/Checkout/WeChatPayDetails.php
@@ -348,11 +348,11 @@ class WeChatPayDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/WeChatPayMiniProgramDetails.php
+++ b/src/Adyen/Model/Checkout/WeChatPayMiniProgramDetails.php
@@ -408,11 +408,11 @@ class WeChatPayMiniProgramDetails implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Checkout/ZipDetails.php
+++ b/src/Adyen/Model/Checkout/ZipDetails.php
@@ -443,11 +443,11 @@ class ZipDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/AULocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/AULocalAccountIdentification.php
@@ -386,11 +386,11 @@ class AULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/AcceptTermsOfServiceResponse.php
+++ b/src/Adyen/Model/LegalEntityManagement/AcceptTermsOfServiceResponse.php
@@ -488,11 +488,11 @@ class AcceptTermsOfServiceResponse implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/AdditionalBankIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/AdditionalBankIdentification.php
@@ -352,11 +352,11 @@ class AdditionalBankIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/BusinessLine.php
+++ b/src/Adyen/Model/LegalEntityManagement/BusinessLine.php
@@ -419,11 +419,11 @@ class BusinessLine implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCapabilityAllowableValues();
         if (!in_array($capability, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'capability', must be one of '%s'",
+                    "capability: unexpected enum value '%s' - Supported values are [%s]",
                     $capability,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -573,11 +573,11 @@ class BusinessLine implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getServiceAllowableValues();
         if (!in_array($service, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'service', must be one of '%s'",
+                    "service: unexpected enum value '%s' - Supported values are [%s]",
                     $service,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/BusinessLineInfo.php
+++ b/src/Adyen/Model/LegalEntityManagement/BusinessLineInfo.php
@@ -402,11 +402,11 @@ class BusinessLineInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCapabilityAllowableValues();
         if (!in_array($capability, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'capability', must be one of '%s'",
+                    "capability: unexpected enum value '%s' - Supported values are [%s]",
                     $capability,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -508,11 +508,11 @@ class BusinessLineInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getServiceAllowableValues();
         if (!in_array($service, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'service', must be one of '%s'",
+                    "service: unexpected enum value '%s' - Supported values are [%s]",
                     $service,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/CALocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/CALocalAccountIdentification.php
@@ -402,11 +402,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -484,11 +484,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/CZLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/CZLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class CZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/CapabilityProblemEntity.php
+++ b/src/Adyen/Model/LegalEntityManagement/CapabilityProblemEntity.php
@@ -414,11 +414,11 @@ class CapabilityProblemEntity implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/CapabilityProblemEntityRecursive.php
+++ b/src/Adyen/Model/LegalEntityManagement/CapabilityProblemEntityRecursive.php
@@ -383,11 +383,11 @@ class CapabilityProblemEntityRecursive implements ModelInterface, ArrayAccess, \
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/CapabilitySettings.php
+++ b/src/Adyen/Model/LegalEntityManagement/CapabilitySettings.php
@@ -444,11 +444,11 @@ class CapabilitySettings implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getIntervalAllowableValues();
         if (!in_array($interval, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'interval', must be one of '%s'",
+                    "interval: unexpected enum value '%s' - Supported values are [%s]",
                     $interval,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/DKLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/DKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class DKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/Document.php
+++ b/src/Adyen/Model/LegalEntityManagement/Document.php
@@ -735,11 +735,11 @@ class Document implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/DocumentPage.php
+++ b/src/Adyen/Model/LegalEntityManagement/DocumentPage.php
@@ -381,11 +381,11 @@ class DocumentPage implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/GetAcceptedTermsOfServiceDocumentResponse.php
+++ b/src/Adyen/Model/LegalEntityManagement/GetAcceptedTermsOfServiceDocumentResponse.php
@@ -412,11 +412,11 @@ class GetAcceptedTermsOfServiceDocumentResponse implements ModelInterface, Array
     {
         $allowedValues = $this->getTermsOfServiceDocumentFormatAllowableValues();
         if (!in_array($termsOfServiceDocumentFormat, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'termsOfServiceDocumentFormat', must be one of '%s'",
+                    "termsOfServiceDocumentFormat: unexpected enum value '%s' - Supported values are [%s]",
                     $termsOfServiceDocumentFormat,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/GetTermsOfServiceDocumentRequest.php
+++ b/src/Adyen/Model/LegalEntityManagement/GetTermsOfServiceDocumentRequest.php
@@ -401,11 +401,11 @@ class GetTermsOfServiceDocumentRequest implements ModelInterface, ArrayAccess, \
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/GetTermsOfServiceDocumentResponse.php
+++ b/src/Adyen/Model/LegalEntityManagement/GetTermsOfServiceDocumentResponse.php
@@ -488,11 +488,11 @@ class GetTermsOfServiceDocumentResponse implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/HKLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/HKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class HKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/HULocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/HULocalAccountIdentification.php
@@ -352,11 +352,11 @@ class HULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/IbanAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/IbanAccountIdentification.php
@@ -352,11 +352,11 @@ class IbanAccountIdentification implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/IdentificationData.php
+++ b/src/Adyen/Model/LegalEntityManagement/IdentificationData.php
@@ -512,11 +512,11 @@ class IdentificationData implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/LegalEntity.php
+++ b/src/Adyen/Model/LegalEntityManagement/LegalEntity.php
@@ -721,11 +721,11 @@ class LegalEntity implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/LegalEntityAssociation.php
+++ b/src/Adyen/Model/LegalEntityManagement/LegalEntityAssociation.php
@@ -603,11 +603,11 @@ class LegalEntityAssociation implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/LegalEntityCapability.php
+++ b/src/Adyen/Model/LegalEntityManagement/LegalEntityCapability.php
@@ -421,11 +421,11 @@ class LegalEntityCapability implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getAllowedLevelAllowableValues();
         if (!in_array($allowedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'allowedLevel', must be one of '%s'",
+                    "allowedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $allowedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -503,11 +503,11 @@ class LegalEntityCapability implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getRequestedLevelAllowableValues();
         if (!in_array($requestedLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'requestedLevel', must be one of '%s'",
+                    "requestedLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $requestedLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/LegalEntityInfo.php
+++ b/src/Adyen/Model/LegalEntityManagement/LegalEntityInfo.php
@@ -554,11 +554,11 @@ class LegalEntityInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/LegalEntityInfoRequiredType.php
+++ b/src/Adyen/Model/LegalEntityManagement/LegalEntityInfoRequiredType.php
@@ -557,11 +557,11 @@ class LegalEntityInfoRequiredType implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/NOLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/NOLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NOLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/NZLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/NZLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/NumberAndBicAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/NumberAndBicAccountIdentification.php
@@ -417,11 +417,11 @@ class NumberAndBicAccountIdentification implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/Organization.php
+++ b/src/Adyen/Model/LegalEntityManagement/Organization.php
@@ -809,11 +809,11 @@ class Organization implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -843,11 +843,11 @@ class Organization implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getVatAbsenceReasonAllowableValues();
         if (!in_array($vatAbsenceReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'vatAbsenceReason', must be one of '%s'",
+                    "vatAbsenceReason: unexpected enum value '%s' - Supported values are [%s]",
                     $vatAbsenceReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/PLLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/PLLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class PLLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/SELocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/SELocalAccountIdentification.php
@@ -386,11 +386,11 @@ class SELocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/SGLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/SGLocalAccountIdentification.php
@@ -383,11 +383,11 @@ class SGLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/SoleProprietorship.php
+++ b/src/Adyen/Model/LegalEntityManagement/SoleProprietorship.php
@@ -653,11 +653,11 @@ class SoleProprietorship implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getVatAbsenceReasonAllowableValues();
         if (!in_array($vatAbsenceReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'vatAbsenceReason', must be one of '%s'",
+                    "vatAbsenceReason: unexpected enum value '%s' - Supported values are [%s]",
                     $vatAbsenceReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/SourceOfFunds.php
+++ b/src/Adyen/Model/LegalEntityManagement/SourceOfFunds.php
@@ -410,11 +410,11 @@ class SourceOfFunds implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/TaxReportingClassification.php
+++ b/src/Adyen/Model/LegalEntityManagement/TaxReportingClassification.php
@@ -402,11 +402,11 @@ class TaxReportingClassification implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getBusinessTypeAllowableValues();
         if (!in_array($businessType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'businessType', must be one of '%s'",
+                    "businessType: unexpected enum value '%s' - Supported values are [%s]",
                     $businessType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -460,11 +460,11 @@ class TaxReportingClassification implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getMainSourceOfIncomeAllowableValues();
         if (!in_array($mainSourceOfIncome, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'mainSourceOfIncome', must be one of '%s'",
+                    "mainSourceOfIncome: unexpected enum value '%s' - Supported values are [%s]",
                     $mainSourceOfIncome,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -494,11 +494,11 @@ class TaxReportingClassification implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/TermsOfServiceAcceptanceInfo.php
+++ b/src/Adyen/Model/LegalEntityManagement/TermsOfServiceAcceptanceInfo.php
@@ -464,11 +464,11 @@ class TermsOfServiceAcceptanceInfo implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/TransferInstrument.php
+++ b/src/Adyen/Model/LegalEntityManagement/TransferInstrument.php
@@ -515,11 +515,11 @@ class TransferInstrument implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/TransferInstrumentInfo.php
+++ b/src/Adyen/Model/LegalEntityManagement/TransferInstrumentInfo.php
@@ -388,11 +388,11 @@ class TransferInstrumentInfo implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/Trust.php
+++ b/src/Adyen/Model/LegalEntityManagement/Trust.php
@@ -686,11 +686,11 @@ class Trust implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -744,11 +744,11 @@ class Trust implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getVatAbsenceReasonAllowableValues();
         if (!in_array($vatAbsenceReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'vatAbsenceReason', must be one of '%s'",
+                    "vatAbsenceReason: unexpected enum value '%s' - Supported values are [%s]",
                     $vatAbsenceReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/UKLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/UKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class UKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/USLocalAccountIdentification.php
+++ b/src/Adyen/Model/LegalEntityManagement/USLocalAccountIdentification.php
@@ -392,11 +392,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -450,11 +450,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/UnincorporatedPartnership.php
+++ b/src/Adyen/Model/LegalEntityManagement/UnincorporatedPartnership.php
@@ -694,11 +694,11 @@ class UnincorporatedPartnership implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -728,11 +728,11 @@ class UnincorporatedPartnership implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getVatAbsenceReasonAllowableValues();
         if (!in_array($vatAbsenceReason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'vatAbsenceReason', must be one of '%s'",
+                    "vatAbsenceReason: unexpected enum value '%s' - Supported values are [%s]",
                     $vatAbsenceReason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/VerificationError.php
+++ b/src/Adyen/Model/LegalEntityManagement/VerificationError.php
@@ -607,11 +607,11 @@ class VerificationError implements ModelInterface, ArrayAccess, \JsonSerializabl
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/VerificationErrorRecursive.php
+++ b/src/Adyen/Model/LegalEntityManagement/VerificationErrorRecursive.php
@@ -552,11 +552,11 @@ class VerificationErrorRecursive implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/LegalEntityManagement/WebDataExemption.php
+++ b/src/Adyen/Model/LegalEntityManagement/WebDataExemption.php
@@ -317,11 +317,11 @@ class WebDataExemption implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/AccountInfo.php
+++ b/src/Adyen/Model/Payments/AccountInfo.php
@@ -586,11 +586,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountAgeIndicatorAllowableValues();
         if (!in_array($accountAgeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountAgeIndicator', must be one of '%s'",
+                    "accountAgeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $accountAgeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -644,11 +644,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountChangeIndicatorAllowableValues();
         if (!in_array($accountChangeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountChangeIndicator', must be one of '%s'",
+                    "accountChangeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $accountChangeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -702,11 +702,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -784,11 +784,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDeliveryAddressUsageIndicatorAllowableValues();
         if (!in_array($deliveryAddressUsageIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryAddressUsageIndicator', must be one of '%s'",
+                    "deliveryAddressUsageIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryAddressUsageIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -894,11 +894,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPasswordChangeIndicatorAllowableValues();
         if (!in_array($passwordChangeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'passwordChangeIndicator', must be one of '%s'",
+                    "passwordChangeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $passwordChangeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1000,11 +1000,11 @@ class AccountInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPaymentAccountIndicatorAllowableValues();
         if (!in_array($paymentAccountIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'paymentAccountIndicator', must be one of '%s'",
+                    "paymentAccountIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $paymentAccountIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/AcctInfo.php
+++ b/src/Adyen/Model/Payments/AcctInfo.php
@@ -586,11 +586,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccAgeIndAllowableValues();
         if (!in_array($chAccAgeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccAgeInd', must be one of '%s'",
+                    "chAccAgeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccAgeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -644,11 +644,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccChangeIndAllowableValues();
         if (!in_array($chAccChangeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccChangeInd', must be one of '%s'",
+                    "chAccChangeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccChangeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -702,11 +702,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChAccPwChangeIndAllowableValues();
         if (!in_array($chAccPwChangeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'chAccPwChangeInd', must be one of '%s'",
+                    "chAccPwChangeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $chAccPwChangeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -808,11 +808,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPaymentAccIndAllowableValues();
         if (!in_array($paymentAccInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'paymentAccInd', must be one of '%s'",
+                    "paymentAccInd: unexpected enum value '%s' - Supported values are [%s]",
                     $paymentAccInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -890,11 +890,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShipAddressUsageIndAllowableValues();
         if (!in_array($shipAddressUsageInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shipAddressUsageInd', must be one of '%s'",
+                    "shipAddressUsageInd: unexpected enum value '%s' - Supported values are [%s]",
                     $shipAddressUsageInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -924,11 +924,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShipNameIndicatorAllowableValues();
         if (!in_array($shipNameIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shipNameIndicator', must be one of '%s'",
+                    "shipNameIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $shipNameIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -958,11 +958,11 @@ class AcctInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getSuspiciousAccActivityAllowableValues();
         if (!in_array($suspiciousAccActivity, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'suspiciousAccActivity', must be one of '%s'",
+                    "suspiciousAccActivity: unexpected enum value '%s' - Supported values are [%s]",
                     $suspiciousAccActivity,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/AdditionalData3DSecure.php
+++ b/src/Adyen/Model/Payments/AdditionalData3DSecure.php
@@ -382,11 +382,11 @@ class AdditionalData3DSecure implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getChallengeWindowSizeAllowableValues();
         if (!in_array($challengeWindowSize, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeWindowSize', must be one of '%s'",
+                    "challengeWindowSize: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeWindowSize,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/AdditionalDataCommon.php
+++ b/src/Adyen/Model/Payments/AdditionalDataCommon.php
@@ -601,11 +601,11 @@ class AdditionalDataCommon implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getIndustryUsageAllowableValues();
         if (!in_array($industryUsage, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'industryUsage', must be one of '%s'",
+                    "industryUsage: unexpected enum value '%s' - Supported values are [%s]",
                     $industryUsage,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/DeviceRenderOptions.php
+++ b/src/Adyen/Model/Payments/DeviceRenderOptions.php
@@ -346,11 +346,11 @@ class DeviceRenderOptions implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getSdkInterfaceAllowableValues();
         if (!in_array($sdkInterface, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'sdkInterface', must be one of '%s'",
+                    "sdkInterface: unexpected enum value '%s' - Supported values are [%s]",
                     $sdkInterface,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/Installments.php
+++ b/src/Adyen/Model/Payments/Installments.php
@@ -374,11 +374,11 @@ class Installments implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPlanAllowableValues();
         if (!in_array($plan, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'plan', must be one of '%s'",
+                    "plan: unexpected enum value '%s' - Supported values are [%s]",
                     $plan,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/Mandate.php
+++ b/src/Adyen/Model/Payments/Mandate.php
@@ -466,11 +466,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAmountRuleAllowableValues();
         if (!in_array($amountRule, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'amountRule', must be one of '%s'",
+                    "amountRule: unexpected enum value '%s' - Supported values are [%s]",
                     $amountRule,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -500,11 +500,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getBillingAttemptsRuleAllowableValues();
         if (!in_array($billingAttemptsRule, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'billingAttemptsRule', must be one of '%s'",
+                    "billingAttemptsRule: unexpected enum value '%s' - Supported values are [%s]",
                     $billingAttemptsRule,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -606,11 +606,11 @@ class Mandate implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFrequencyAllowableValues();
         if (!in_array($frequency, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'frequency', must be one of '%s'",
+                    "frequency: unexpected enum value '%s' - Supported values are [%s]",
                     $frequency,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/MerchantRiskIndicator.php
+++ b/src/Adyen/Model/Payments/MerchantRiskIndicator.php
@@ -469,11 +469,11 @@ class MerchantRiskIndicator implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getDeliveryAddressIndicatorAllowableValues();
         if (!in_array($deliveryAddressIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryAddressIndicator', must be one of '%s'",
+                    "deliveryAddressIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryAddressIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -553,11 +553,11 @@ class MerchantRiskIndicator implements ModelInterface, ArrayAccess, \JsonSeriali
     {
         $allowedValues = $this->getDeliveryTimeframeAllowableValues();
         if (!in_array($deliveryTimeframe, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'deliveryTimeframe', must be one of '%s'",
+                    "deliveryTimeframe: unexpected enum value '%s' - Supported values are [%s]",
                     $deliveryTimeframe,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ModificationResult.php
+++ b/src/Adyen/Model/Payments/ModificationResult.php
@@ -399,11 +399,11 @@ class ModificationResult implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getResponseAllowableValues();
         if (!in_array($response, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'response', must be one of '%s'",
+                    "response: unexpected enum value '%s' - Supported values are [%s]",
                     $response,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ObjectSerializer.php
+++ b/src/Adyen/Model/Payments/ObjectSerializer.php
@@ -82,7 +82,7 @@ class ObjectSerializer
                     }
                 }
             } else {
-                foreach ($data as $property => $value) {
+                foreach($data as $property => $value) {
                     $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
@@ -118,9 +118,7 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) {
-            return $timestamp;
-        }
+        if (!is_string($timestamp)) return $timestamp;
 
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }

--- a/src/Adyen/Model/Payments/ObjectSerializer.php
+++ b/src/Adyen/Model/Payments/ObjectSerializer.php
@@ -82,7 +82,7 @@ class ObjectSerializer
                     }
                 }
             } else {
-                foreach($data as $property => $value) {
+                foreach ($data as $property => $value) {
                     $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
@@ -118,7 +118,9 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) return $timestamp;
+        if (!is_string($timestamp)) {
+            return $timestamp;
+        }
 
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }

--- a/src/Adyen/Model/Payments/PaymentRequest.php
+++ b/src/Adyen/Model/Payments/PaymentRequest.php
@@ -1132,11 +1132,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getEntityTypeAllowableValues();
         if (!in_array($entityType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'entityType', must be one of '%s'",
+                    "entityType: unexpected enum value '%s' - Supported values are [%s]",
                     $entityType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1238,11 +1238,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getFundingSourceAllowableValues();
         if (!in_array($fundingSource, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fundingSource', must be one of '%s'",
+                    "fundingSource: unexpected enum value '%s' - Supported values are [%s]",
                     $fundingSource,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1584,11 +1584,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1786,11 +1786,11 @@ class PaymentRequest implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/PaymentRequest3d.php
+++ b/src/Adyen/Model/Payments/PaymentRequest3d.php
@@ -1263,11 +1263,11 @@ class PaymentRequest3d implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1441,11 +1441,11 @@ class PaymentRequest3d implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/PaymentRequest3ds2.php
+++ b/src/Adyen/Model/Payments/PaymentRequest3ds2.php
@@ -1215,11 +1215,11 @@ class PaymentRequest3ds2 implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1393,11 +1393,11 @@ class PaymentRequest3ds2 implements ModelInterface, ArrayAccess, \JsonSerializab
     {
         $allowedValues = $this->getShopperInteractionAllowableValues();
         if (!in_array($shopperInteraction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'shopperInteraction', must be one of '%s'",
+                    "shopperInteraction: unexpected enum value '%s' - Supported values are [%s]",
                     $shopperInteraction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/PaymentResult.php
+++ b/src/Adyen/Model/Payments/PaymentResult.php
@@ -651,11 +651,11 @@ class PaymentResult implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getResultCodeAllowableValues();
         if (!in_array($resultCode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'resultCode', must be one of '%s'",
+                    "resultCode: unexpected enum value '%s' - Supported values are [%s]",
                     $resultCode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/PlatformChargebackLogic.php
+++ b/src/Adyen/Model/Payments/PlatformChargebackLogic.php
@@ -333,11 +333,11 @@ class PlatformChargebackLogic implements ModelInterface, ArrayAccess, \JsonSeria
     {
         $allowedValues = $this->getBehaviorAllowableValues();
         if (!in_array($behavior, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'behavior', must be one of '%s'",
+                    "behavior: unexpected enum value '%s' - Supported values are [%s]",
                     $behavior,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/Recurring.php
+++ b/src/Adyen/Model/Payments/Recurring.php
@@ -374,11 +374,11 @@ class Recurring implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getContractAllowableValues();
         if (!in_array($contract, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'contract', must be one of '%s'",
+                    "contract: unexpected enum value '%s' - Supported values are [%s]",
                     $contract,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -480,11 +480,11 @@ class Recurring implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTokenServiceAllowableValues();
         if (!in_array($tokenService, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'tokenService', must be one of '%s'",
+                    "tokenService: unexpected enum value '%s' - Supported values are [%s]",
                     $tokenService,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ResponseAdditionalDataCard.php
+++ b/src/Adyen/Model/Payments/ResponseAdditionalDataCard.php
@@ -535,11 +535,11 @@ class ResponseAdditionalDataCard implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getCardProductIdAllowableValues();
         if (!in_array($cardProductId, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'cardProductId', must be one of '%s'",
+                    "cardProductId: unexpected enum value '%s' - Supported values are [%s]",
                     $cardProductId,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ResponseAdditionalDataCommon.php
+++ b/src/Adyen/Model/Payments/ResponseAdditionalDataCommon.php
@@ -1358,11 +1358,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getFraudResultTypeAllowableValues();
         if (!in_array($fraudResultType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fraudResultType', must be one of '%s'",
+                    "fraudResultType: unexpected enum value '%s' - Supported values are [%s]",
                     $fraudResultType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1392,11 +1392,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getFraudRiskLevelAllowableValues();
         if (!in_array($fraudRiskLevel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'fraudRiskLevel', must be one of '%s'",
+                    "fraudRiskLevel: unexpected enum value '%s' - Supported values are [%s]",
                     $fraudRiskLevel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1934,11 +1934,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getRecurringProcessingModelAllowableValues();
         if (!in_array($recurringProcessingModel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'recurringProcessingModel', must be one of '%s'",
+                    "recurringProcessingModel: unexpected enum value '%s' - Supported values are [%s]",
                     $recurringProcessingModel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -2280,11 +2280,11 @@ class ResponseAdditionalDataCommon implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTokenizationStoreOperationTypeAllowableValues();
         if (!in_array($tokenizationStoreOperationType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'tokenizationStoreOperationType', must be one of '%s'",
+                    "tokenizationStoreOperationType: unexpected enum value '%s' - Supported values are [%s]",
                     $tokenizationStoreOperationType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/SecureRemoteCommerceCheckoutData.php
+++ b/src/Adyen/Model/Payments/SecureRemoteCommerceCheckoutData.php
@@ -448,11 +448,11 @@ class SecureRemoteCommerceCheckoutData implements ModelInterface, ArrayAccess, \
     {
         $allowedValues = $this->getSchemeAllowableValues();
         if (!in_array($scheme, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'scheme', must be one of '%s'",
+                    "scheme: unexpected enum value '%s' - Supported values are [%s]",
                     $scheme,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/Split.php
+++ b/src/Adyen/Model/Payments/Split.php
@@ -472,11 +472,11 @@ class Split implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ThreeDS2RequestData.php
+++ b/src/Adyen/Model/Payments/ThreeDS2RequestData.php
@@ -751,11 +751,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getAcctTypeAllowableValues();
         if (!in_array($acctType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'acctType', must be one of '%s'",
+                    "acctType: unexpected enum value '%s' - Supported values are [%s]",
                     $acctType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -833,11 +833,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getAddrMatchAllowableValues();
         if (!in_array($addrMatch, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'addrMatch', must be one of '%s'",
+                    "addrMatch: unexpected enum value '%s' - Supported values are [%s]",
                     $addrMatch,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -895,11 +895,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getChallengeIndicatorAllowableValues();
         if (!in_array($challengeIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeIndicator', must be one of '%s'",
+                    "challengeIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1481,11 +1481,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1611,11 +1611,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTransTypeAllowableValues();
         if (!in_array($transType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transType', must be one of '%s'",
+                    "transType: unexpected enum value '%s' - Supported values are [%s]",
                     $transType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1645,11 +1645,11 @@ class ThreeDS2RequestData implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTransactionTypeAllowableValues();
         if (!in_array($transactionType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'transactionType', must be one of '%s'",
+                    "transactionType: unexpected enum value '%s' - Supported values are [%s]",
                     $transactionType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ThreeDS2Result.php
+++ b/src/Adyen/Model/Payments/ThreeDS2Result.php
@@ -524,11 +524,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChallengeCancelAllowableValues();
         if (!in_array($challengeCancel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeCancel', must be one of '%s'",
+                    "challengeCancel: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeCancel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -606,11 +606,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getExemptionIndicatorAllowableValues();
         if (!in_array($exemptionIndicator, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'exemptionIndicator', must be one of '%s'",
+                    "exemptionIndicator: unexpected enum value '%s' - Supported values are [%s]",
                     $exemptionIndicator,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -688,11 +688,11 @@ class ThreeDS2Result implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getThreeDSRequestorChallengeIndAllowableValues();
         if (!in_array($threeDSRequestorChallengeInd, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSRequestorChallengeInd', must be one of '%s'",
+                    "threeDSRequestorChallengeInd: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSRequestorChallengeInd,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ThreeDSRequestorAuthenticationInfo.php
+++ b/src/Adyen/Model/Payments/ThreeDSRequestorAuthenticationInfo.php
@@ -363,11 +363,11 @@ class ThreeDSRequestorAuthenticationInfo implements ModelInterface, ArrayAccess,
     {
         $allowedValues = $this->getThreeDSReqAuthMethodAllowableValues();
         if (!in_array($threeDSReqAuthMethod, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSReqAuthMethod', must be one of '%s'",
+                    "threeDSReqAuthMethod: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSReqAuthMethod,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ThreeDSRequestorPriorAuthenticationInfo.php
+++ b/src/Adyen/Model/Payments/ThreeDSRequestorPriorAuthenticationInfo.php
@@ -366,11 +366,11 @@ class ThreeDSRequestorPriorAuthenticationInfo implements ModelInterface, ArrayAc
     {
         $allowedValues = $this->getThreeDSReqPriorAuthMethodAllowableValues();
         if (!in_array($threeDSReqPriorAuthMethod, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'threeDSReqPriorAuthMethod', must be one of '%s'",
+                    "threeDSReqPriorAuthMethod: unexpected enum value '%s' - Supported values are [%s]",
                     $threeDSReqPriorAuthMethod,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Payments/ThreeDSecureData.php
+++ b/src/Adyen/Model/Payments/ThreeDSecureData.php
@@ -466,11 +466,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAuthenticationResponseAllowableValues();
         if (!in_array($authenticationResponse, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'authenticationResponse', must be one of '%s'",
+                    "authenticationResponse: unexpected enum value '%s' - Supported values are [%s]",
                     $authenticationResponse,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -548,11 +548,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getChallengeCancelAllowableValues();
         if (!in_array($challengeCancel, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'challengeCancel', must be one of '%s'",
+                    "challengeCancel: unexpected enum value '%s' - Supported values are [%s]",
                     $challengeCancel,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -582,11 +582,11 @@ class ThreeDSecureData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDirectoryResponseAllowableValues();
         if (!in_array($directoryResponse, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'directoryResponse', must be one of '%s'",
+                    "directoryResponse: unexpected enum value '%s' - Supported values are [%s]",
                     $directoryResponse,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/AULocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/AULocalAccountIdentification.php
@@ -386,11 +386,11 @@ class AULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/AdditionalBankIdentification.php
+++ b/src/Adyen/Model/Transfers/AdditionalBankIdentification.php
@@ -352,11 +352,11 @@ class AdditionalBankIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/AmountAdjustment.php
+++ b/src/Adyen/Model/Transfers/AmountAdjustment.php
@@ -359,11 +359,11 @@ class AmountAdjustment implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getAmountAdjustmentTypeAllowableValues();
         if (!in_array($amountAdjustmentType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'amountAdjustmentType', must be one of '%s'",
+                    "amountAdjustmentType: unexpected enum value '%s' - Supported values are [%s]",
                     $amountAdjustmentType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/BRLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/BRLocalAccountIdentification.php
@@ -451,11 +451,11 @@ class BRLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/BankCategoryData.php
+++ b/src/Adyen/Model/Transfers/BankCategoryData.php
@@ -353,11 +353,11 @@ class BankCategoryData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPriorityAllowableValues();
         if (!in_array($priority, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'priority', must be one of '%s'",
+                    "priority: unexpected enum value '%s' - Supported values are [%s]",
                     $priority,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -387,11 +387,11 @@ class BankCategoryData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/CALocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/CALocalAccountIdentification.php
@@ -402,11 +402,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -484,11 +484,11 @@ class CALocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/CZLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/CZLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class CZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/CapitalGrant.php
+++ b/src/Adyen/Model/Transfers/CapitalGrant.php
@@ -588,11 +588,11 @@ class CapitalGrant implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/ConfirmationTrackingData.php
+++ b/src/Adyen/Model/Transfers/ConfirmationTrackingData.php
@@ -349,11 +349,11 @@ class ConfirmationTrackingData implements ModelInterface, ArrayAccess, \JsonSeri
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -383,11 +383,11 @@ class ConfirmationTrackingData implements ModelInterface, ArrayAccess, \JsonSeri
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/DKLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/DKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class DKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/EstimationTrackingData.php
+++ b/src/Adyen/Model/Transfers/EstimationTrackingData.php
@@ -352,11 +352,11 @@ class EstimationTrackingData implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/HKLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/HKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class HKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/HULocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/HULocalAccountIdentification.php
@@ -352,11 +352,11 @@ class HULocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/IbanAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/IbanAccountIdentification.php
@@ -352,11 +352,11 @@ class IbanAccountIdentification implements ModelInterface, ArrayAccess, \JsonSer
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/InternalCategoryData.php
+++ b/src/Adyen/Model/Transfers/InternalCategoryData.php
@@ -377,11 +377,11 @@ class InternalCategoryData implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/InternalReviewTrackingData.php
+++ b/src/Adyen/Model/Transfers/InternalReviewTrackingData.php
@@ -379,11 +379,11 @@ class InternalReviewTrackingData implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -413,11 +413,11 @@ class InternalReviewTrackingData implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -447,11 +447,11 @@ class InternalReviewTrackingData implements ModelInterface, ArrayAccess, \JsonSe
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/IssuedCard.php
+++ b/src/Adyen/Model/Transfers/IssuedCard.php
@@ -463,11 +463,11 @@ class IssuedCard implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPanEntryModeAllowableValues();
         if (!in_array($panEntryMode, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'panEntryMode', must be one of '%s'",
+                    "panEntryMode: unexpected enum value '%s' - Supported values are [%s]",
                     $panEntryMode,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -497,11 +497,11 @@ class IssuedCard implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getProcessingTypeAllowableValues();
         if (!in_array($processingType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'processingType', must be one of '%s'",
+                    "processingType: unexpected enum value '%s' - Supported values are [%s]",
                     $processingType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -627,11 +627,11 @@ class IssuedCard implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/IssuingTransactionData.php
+++ b/src/Adyen/Model/Transfers/IssuingTransactionData.php
@@ -349,11 +349,11 @@ class IssuingTransactionData implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/MerchantPurchaseData.php
+++ b/src/Adyen/Model/Transfers/MerchantPurchaseData.php
@@ -380,11 +380,11 @@ class MerchantPurchaseData implements ModelInterface, ArrayAccess, \JsonSerializ
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/Modification.php
+++ b/src/Adyen/Model/Transfers/Modification.php
@@ -547,11 +547,11 @@ class Modification implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/NOLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/NOLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NOLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/NZLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/NZLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class NZLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/NumberAndBicAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/NumberAndBicAccountIdentification.php
@@ -417,11 +417,11 @@ class NumberAndBicAccountIdentification implements ModelInterface, ArrayAccess, 
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/PLLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/PLLocalAccountIdentification.php
@@ -352,11 +352,11 @@ class PLLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/PartyIdentification.php
+++ b/src/Adyen/Model/Transfers/PartyIdentification.php
@@ -543,11 +543,11 @@ class PartyIdentification implements ModelInterface, ArrayAccess, \JsonSerializa
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/PlatformPayment.php
+++ b/src/Adyen/Model/Transfers/PlatformPayment.php
@@ -475,11 +475,11 @@ class PlatformPayment implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPlatformPaymentTypeAllowableValues();
         if (!in_array($platformPaymentType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'platformPaymentType', must be one of '%s'",
+                    "platformPaymentType: unexpected enum value '%s' - Supported values are [%s]",
                     $platformPaymentType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -533,11 +533,11 @@ class PlatformPayment implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/ReturnTransferResponse.php
+++ b/src/Adyen/Model/Transfers/ReturnTransferResponse.php
@@ -386,11 +386,11 @@ class ReturnTransferResponse implements ModelInterface, ArrayAccess, \JsonSerial
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/RoutingDetails.php
+++ b/src/Adyen/Model/Transfers/RoutingDetails.php
@@ -394,11 +394,11 @@ class RoutingDetails implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPriorityAllowableValues();
         if (!in_array($priority, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'priority', must be one of '%s'",
+                    "priority: unexpected enum value '%s' - Supported values are [%s]",
                     $priority,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/SELocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/SELocalAccountIdentification.php
@@ -386,11 +386,11 @@ class SELocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/SGLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/SGLocalAccountIdentification.php
@@ -383,11 +383,11 @@ class SGLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/Transaction.php
+++ b/src/Adyen/Model/Transfers/Transaction.php
@@ -665,11 +665,11 @@ class Transaction implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/Transfer.php
+++ b/src/Adyen/Model/Transfers/Transfer.php
@@ -882,11 +882,11 @@ class Transfer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1062,11 +1062,11 @@ class Transfer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDirectionAllowableValues();
         if (!in_array($direction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'direction', must be one of '%s'",
+                    "direction: unexpected enum value '%s' - Supported values are [%s]",
                     $direction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1168,11 +1168,11 @@ class Transfer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1274,11 +1274,11 @@ class Transfer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1308,11 +1308,11 @@ class Transfer implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/TransferData.php
+++ b/src/Adyen/Model/Transfers/TransferData.php
@@ -990,11 +990,11 @@ class TransferData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1170,11 +1170,11 @@ class TransferData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getDirectionAllowableValues();
         if (!in_array($direction, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'direction', must be one of '%s'",
+                    "direction: unexpected enum value '%s' - Supported values are [%s]",
                     $direction,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1348,11 +1348,11 @@ class TransferData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1478,11 +1478,11 @@ class TransferData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1560,11 +1560,11 @@ class TransferData implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/TransferEvent.php
+++ b/src/Adyen/Model/Transfers/TransferEvent.php
@@ -922,11 +922,11 @@ class TransferEvent implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getReasonAllowableValues();
         if (!in_array($reason, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'reason', must be one of '%s'",
+                    "reason: unexpected enum value '%s' - Supported values are [%s]",
                     $reason,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -956,11 +956,11 @@ class TransferEvent implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    "status: unexpected enum value '%s' - Supported values are [%s]",
                     $status,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -1038,11 +1038,11 @@ class TransferEvent implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/TransferInfo.php
+++ b/src/Adyen/Model/Transfers/TransferInfo.php
@@ -551,11 +551,11 @@ class TransferInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getCategoryAllowableValues();
         if (!in_array($category, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'category', must be one of '%s'",
+                    "category: unexpected enum value '%s' - Supported values are [%s]",
                     $category,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -714,11 +714,11 @@ class TransferInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getPriorityAllowableValues();
         if (!in_array($priority, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'priority', must be one of '%s'",
+                    "priority: unexpected enum value '%s' - Supported values are [%s]",
                     $priority,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -820,11 +820,11 @@ class TransferInfo implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/TransferReview.php
+++ b/src/Adyen/Model/Transfers/TransferReview.php
@@ -350,11 +350,11 @@ class TransferReview implements ModelInterface, ArrayAccess, \JsonSerializable
     {
         $allowedValues = $this->getScaOnApprovalAllowableValues();
         if (!in_array($scaOnApproval, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'scaOnApproval', must be one of '%s'",
+                    "scaOnApproval: unexpected enum value '%s' - Supported values are [%s]",
                     $scaOnApproval,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/UKLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/UKLocalAccountIdentification.php
@@ -386,11 +386,11 @@ class UKLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/USLocalAccountIdentification.php
+++ b/src/Adyen/Model/Transfers/USLocalAccountIdentification.php
@@ -392,11 +392,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getAccountTypeAllowableValues();
         if (!in_array($accountType, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'accountType', must be one of '%s'",
+                    "accountType: unexpected enum value '%s' - Supported values are [%s]",
                     $accountType,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }
@@ -450,11 +450,11 @@ class USLocalAccountIdentification implements ModelInterface, ArrayAccess, \Json
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Model/Transfers/UltimatePartyIdentification.php
+++ b/src/Adyen/Model/Transfers/UltimatePartyIdentification.php
@@ -543,11 +543,11 @@ class UltimatePartyIdentification implements ModelInterface, ArrayAccess, \JsonS
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for 'type', must be one of '%s'",
+                    "type: unexpected enum value '%s' - Supported values are [%s]",
                     $type,
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }

--- a/src/Adyen/Service/Checkout/RecurringApi.php
+++ b/src/Adyen/Service/Checkout/RecurringApi.php
@@ -44,14 +44,13 @@ class RecurringApi extends Service
     *
     * @param string $storedPaymentMethodId
     * @param array|null $requestOptions ['queryParams' => ['shopperReference'=> string, 'merchantAccount'=> string]]
-    
+
     * @throws AdyenException
     */
     public function deleteTokenForStoredPaymentDetails(string $storedPaymentMethodId, ?array $requestOptions = null)
     {
         $endpoint = $this->baseURL . str_replace(['{storedPaymentMethodId}'], [$storedPaymentMethodId], "/storedPaymentMethods/{storedPaymentMethodId}");
         $this->requestHttp($endpoint, strtolower('DELETE'), null, $requestOptions);
-        
     }
 
     /**

--- a/src/Adyen/Service/Checkout/RecurringApi.php
+++ b/src/Adyen/Service/Checkout/RecurringApi.php
@@ -44,13 +44,14 @@ class RecurringApi extends Service
     *
     * @param string $storedPaymentMethodId
     * @param array|null $requestOptions ['queryParams' => ['shopperReference'=> string, 'merchantAccount'=> string]]
-
+    
     * @throws AdyenException
     */
     public function deleteTokenForStoredPaymentDetails(string $storedPaymentMethodId, ?array $requestOptions = null)
     {
         $endpoint = $this->baseURL . str_replace(['{storedPaymentMethodId}'], [$storedPaymentMethodId], "/storedPaymentMethods/{storedPaymentMethodId}");
         $this->requestHttp($endpoint, strtolower('DELETE'), null, $requestOptions);
+        
     }
 
     /**

--- a/src/Adyen/Service/Checkout/UtilityApi.php
+++ b/src/Adyen/Service/Checkout/UtilityApi.php
@@ -57,7 +57,7 @@ class UtilityApi extends Service
     /**
     * Create originKey values for domains
     *
-    * @deprecated since Adyen Checkout API v67. 
+    * @deprecated since Adyen Checkout API v67.
     * @param \Adyen\Model\Checkout\UtilityRequest $utilityRequest
     * @param array|null $requestOptions
     * @return \Adyen\Model\Checkout\UtilityResponse

--- a/src/Adyen/Service/Checkout/UtilityApi.php
+++ b/src/Adyen/Service/Checkout/UtilityApi.php
@@ -57,7 +57,7 @@ class UtilityApi extends Service
     /**
     * Create originKey values for domains
     *
-    * @deprecated since Adyen Checkout API v67.
+    * @deprecated since Adyen Checkout API v67. 
     * @param \Adyen\Model\Checkout\UtilityRequest $utilityRequest
     * @param array|null $requestOptions
     * @return \Adyen\Model\Checkout\UtilityResponse

--- a/templates/model_generic.mustache
+++ b/templates/model_generic.mustache
@@ -367,11 +367,11 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         $allowedValues = $this->{{getter}}AllowableValues();
         {{^isContainer}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}!in_array(${{{name}}}, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            error_log(
                 sprintf(
-                    "Invalid value '%s' for '{{name}}', must be one of '%s'",
+                    "{{name}}: unexpected enum value '%s' - Supported values are [%s]",
                     ${{{name}}},
-                    implode("', '", $allowedValues)
+                    implode(', ', $allowedValues)
                 )
             );
         }


### PR DESCRIPTION
When an unknown enum value is found in the JSON payload (API response, webhook request) the deserialization throws an exception. This PR makes the deserialization logic more robust to be able to handle unknown enum values

The Mustache templates have been update to log a warning, instead of throwing an `IllegalArgumentException`.
Unit tests have been added to verify the deserialization code.
Several API models have been re-generated.

## Implementation Details

When parsing a JSON payload and encountering unknown enumsm we have 2 options:

1. strict validation throwing `IllegalArgumentException` if the value is unknown
2. don't fail and ignore

We have adopted the latter as it allows us to be resilient when new enums appear in the API responses.



