### PR TITLE
feat(ci): move formatting step before PR creation

### DIFF
--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -1,0 +1,24 @@
+name: 'Format PHP Code'
+description: 'Runs composer run fmt'
+inputs:
+  path:
+    description: 'Path to the php repository'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
+      with:
+        php-version: 8.2
+        tools: composer:v2
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+      shell: bash
+      working-directory: ${{ inputs.path }}
+
+    - name: Run PHP Code Sniffer
+      run: composer run fmt
+      shell: bash
+      working-directory: ${{ inputs.path }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,34 +1,29 @@
-name: PHP Format
+name: Format and Commit PHP Code
 
 on:
-  push:
-    branches:
-      - 'sdk-automation/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   format:
-    if: ${{ github.event.commits != null && !startsWith(github.event.head_commit.message, 'style(fmt)') }}      
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
+      - name: Format PHP Code
+        uses: ./.github/actions/format
         with:
-          php-version: 8.2
-          tools: composer:v2
+          path: .
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run PHP Code Sniffer
-        run: composer run fmt || true
-
-      - run: |
+      - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+        run: |
           git config user.name AdyenAutomationBot
           git config user.email "${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}"
           git add .


### PR DESCRIPTION
Creates a reusable GitHub action for code formatting. Updates the format workflow to use this action and be manually triggerable.

This change is to allow the `sdk-automation-repo` to run the formatting step before creating a pull request, ensuring that generated code is already formatted.
