### PR TITLE
FIx Function curl_close() is deprecated since 8.5 (#918)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.3', '8.2', '8.4' ]
+        php-version: [ '7.3', '8.2', '8.4', '8.5' ]
         include:
           - php-version: '8.2'
             validate: true

--- a/src/Adyen/HttpClient/CurlClient.php
+++ b/src/Adyen/HttpClient/CurlClient.php
@@ -147,7 +147,11 @@ class CurlClient implements ClientInterface
         // Get errors
         [$errno] = $this->curlError($ch);
 
-        curl_close($ch);
+        // On PHP < 8.0 curl handles are resources and must be closed explicitly.
+        // On PHP >= 8.0 they are CurlHandle objects that are garbage collected automatically.
+        if (is_resource($ch)) {
+            curl_close($ch);
+        }
 
         $resultOKHttpStatusCodes = array(200, 201, 202, 204);
 
@@ -354,7 +358,11 @@ class CurlClient implements ClientInterface
         // Get errors
         [$errno] = $this->curlError($ch);
 
-        curl_close($ch);
+        // On PHP < 8.0 curl handles are resources and must be closed explicitly.
+        // On PHP >= 8.0 they are CurlHandle objects that are garbage collected automatically.
+        if (is_resource($ch)) {
+            curl_close($ch);
+        }
 
         $hasFailed = !in_array($httpStatus, array(200, 201, 202, 204));
 


### PR DESCRIPTION
### Description 
Guards the two curl_close($ch) calls in CurlClient.php with is_resource($ch) so they only run on PHP < 8.0, avoiding the PHP 8.5 deprecation notice while preserving cleanup on older PHP versions, and adds PHP 8.5 to the CI matrix.

#### Tested scenarios 
Reproduced the deprecation notice on PHP 8.5.6 before the fix and confirmed it's gone after the fix, then ran the full unit suite (288 tests, 558 assertions) on PHP 8.5.6 with no failures or deprecation output.

**Fixed issue**: #918