### PR TITLE
chore: convert deprecations to error

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,7 @@
         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         colors="true"
+        convertDeprecationsToExceptions="true"
 >
     <php>
         <ini name="display_errors" value="On"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -317,7 +317,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
         }
 
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
+        // Required before PHP 8.1 to invoke non-public methods, and has no effect in newer PHP versions.
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
         return $method;
     }
 


### PR DESCRIPTION
**Description**

This is a follow-up action to prevent use of deprecated methods in the codebase. It uses `phpunit` to convert warnings to errors. Another commit also fixes a deprecation on tests.

**Tested scenarios**

- CI runs across different PHP versions
