### PR TITLE
fix(hmac): stop dropping notification fields whose value is the string "0"

### DIFF
--- a/src/Adyen/Util/HmacSignature.php
+++ b/src/Adyen/Util/HmacSignature.php
@@ -86,25 +86,15 @@ class HmacSignature
      */
     private function getNotificationDataToSign($params)
     {
-        $pspReference = (!empty($params['pspReference'])) ? $params['pspReference'] : "";
-        $originalReference = (!empty($params['originalReference'])) ? $params['originalReference'] : "";
-        $merchantAccountCode = (!empty($params['merchantAccountCode'])) ? $params['merchantAccountCode'] : "";
-        $merchantReference = (!empty($params['merchantReference'])) ? $params['merchantReference'] : "";
-        // `empty` treats too many value types as empty. `isset` should prevent some of these cases.
-        $value = (isset($params['amount']['value'])) ? $params['amount']['value'] : "";
-        $currency = (!empty($params['amount']['currency'])) ? $params['amount']['currency'] : "";
-        $eventCode = (!empty($params[self::EVENT_CODE])) ? $params[self::EVENT_CODE] : "";
-        $success = (!empty($params['success'])) ? $params['success'] : "";
-
         $dataToSign = array(
-            $pspReference,
-            $originalReference,
-            $merchantAccountCode,
-            $merchantReference,
-            $value,
-            $currency,
-            $eventCode,
-            $success
+            $params['pspReference'] ?? "",
+            $params['originalReference'] ?? "",
+            $params['merchantAccountCode'] ?? "",
+            $params['merchantReference'] ?? "",
+            $params['amount']['value'] ?? "",
+            $params['amount']['currency'] ?? "",
+            $params[self::EVENT_CODE] ?? "",
+            $params['success'] ?? ""
         );
 
         return implode(":", $dataToSign);

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -151,6 +151,79 @@ JSON
         }
     }
 
+    public function testMerchantReferenceZeroIsNotTreatedAsEmpty()
+    {
+        $params = json_decode('{
+                "pspReference": "7914073381342284",
+                "merchantAccountCode": "TestMerchant",
+                "merchantReference": "0",
+                "amount": {
+                    "value": 1130,
+                    "currency": "EUR"
+                },
+                "eventCode": "AUTHORISATION",
+                "success": "true"
+            }', true);
+        $key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
+        $hmac = new HmacSignature();
+        $hmacCalculation = $hmac->calculateNotificationHMAC($key, $params);
+        $this->assertEquals("FxamuQrBMUCLGp4jK2kwgsURDS1pD6NjMXLZz5Ls1nI=", $hmacCalculation);
+
+        $params['additionalData'] = array('hmacSignature' => $hmacCalculation);
+        $this->assertTrue($hmac->isValidNotificationHMAC($key, $params));
+    }
+
+    /**
+     * @dataProvider zeroStringFieldProvider
+     */
+    public function testFieldContainingZeroDoesNotCollideWithEmptyField($field, $expectedHmac)
+    {
+        $key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
+        $hmac = new HmacSignature();
+
+        $withZero = $this->notificationWithField($field, "0");
+        $withEmpty = $this->notificationWithField($field, "");
+
+        $zeroHmac = $hmac->calculateNotificationHMAC($key, $withZero);
+        $emptyHmac = $hmac->calculateNotificationHMAC($key, $withEmpty);
+
+        $this->assertEquals($expectedHmac, $zeroHmac);
+        $this->assertNotEquals($emptyHmac, $zeroHmac);
+    }
+
+    public static function zeroStringFieldProvider()
+    {
+        return array(
+            'pspReference' => array('pspReference', 'jh8PoPf6ROKe7ji5v20s41Fb/TEzRTItgID1qHY240Q='),
+            'originalReference' => array('originalReference', '3GHN2RNrz0GHIdbdfN55JqDebcNObEmRG79Bs6Fpx80='),
+            'merchantAccountCode' => array('merchantAccountCode', 'C17xGwk4PJHQMS/PDA2ho+tGRCvCXMTQ0u+CiuXbJlQ='),
+            'merchantReference' => array('merchantReference', 'FxamuQrBMUCLGp4jK2kwgsURDS1pD6NjMXLZz5Ls1nI='),
+            'currency' => array('currency', 'V3hcM/Zbi+UyxllxicWpEYIiWSAwWQ7kEFU/NzjRfPQ='),
+            'eventCode' => array('eventCode', 'z5vWmtlmAQL4a0h2wfdnjHjknlkTP4v8vnfNr0/FFzg='),
+        );
+    }
+
+    private function notificationWithField($field, $value)
+    {
+        $params = array(
+            'pspReference' => '7914073381342284',
+            'originalReference' => '',
+            'merchantAccountCode' => 'TestMerchant',
+            'merchantReference' => 'TestPayment-1407325143704',
+            'amount' => array('value' => 1130, 'currency' => 'EUR'),
+            'eventCode' => 'AUTHORISATION',
+            'success' => 'true',
+        );
+
+        if ($field === 'currency') {
+            $params['amount']['currency'] = $value;
+        } else {
+            $params[$field] = $value;
+        }
+
+        return $params;
+    }
+
     public function testIsHmacSupportedEventCode()
     {
         $params = json_decode('{

--- a/tests/Unit/Util/HmacSignatureTest.php
+++ b/tests/Unit/Util/HmacSignatureTest.php
@@ -215,8 +215,8 @@ JSON
             'success' => 'true',
         );
 
-        if ($field === 'currency') {
-            $params['amount']['currency'] = $value;
+        if ($field === 'currency' || $field === 'value') {
+            $params['amount'][$field] = $value;
         } else {
             $params[$field] = $value;
         }


### PR DESCRIPTION
**Description**

`getNotificationDataToSign()` defaults every field with `empty()`. In PHP `empty("0")` is true, so a signed field holding the string `"0"` goes into the signing string as `""`. Adyen computes its signature over the real value, so a legitimate webhook fails validation. The realistic one to hit is `merchantReference` of `"0"`, but the same holds for `pspReference`, `originalReference`, `merchantAccountCode`, `amount.currency`, `eventCode` and `success`.

`amount.value` was already moved to `isset` for exactly this reason, and the comment on that line says so. I applied the same treatment to the remaining seven fields using `??`.

The signed field list is the documented one, `pspReference:originalReference:merchantAccountCode:merchantReference:value:currency:eventCode:success`, and only the defaulting of those values changes here. Nothing about separators or escaping is touched.

**Tested scenarios**

The signing string is one contract with several implementations, so I used the sibling SDKs as the oracle. For each of the 6 cleanly comparable fields I built the same notification item and compared signatures from adyen-python, adyen-java, adyen-go and adyen-node. All four agree with each other on all 6 cases, and this library was the only one that disagreed, on all 6. After the fix it matches all four.

I also ran the 4 real Adyen-signed fixtures that ship in adyen-python-api-library (`test/mocks/util/*_notification.json`, the ones carrying colons and backslashes in `merchantReference`) through `isValidNotificationHMAC` here. All 4 still validate, so values Adyen signs today are unaffected.

New tests are `testMerchantReferenceZeroIsNotTreatedAsEmpty` and a 6 case data provider asserting that `"0"` and `""` do not collapse to the same signature. Reverting only `HmacSignature.php` and keeping the new tests gives 7 failures; with the fix the unit suite is 295/295 green, up from 288.

Not covered: `success` only ever carries `"true"` or `"false"` from Adyen and the Java model types it as a bool, so I could not derive a cross SDK constant for it. It is defaulted consistently in the fix but has no pinned test vector.

I used Claude Code to build the cross SDK harness and draft the tests. I ran and checked every signature and test result myself.

**Fixed issue**: n/a
